### PR TITLE
Fix RadioAsCheckbox layout and reviewer filtering

### DIFF
--- a/frontend/src/components/input/RadioAsCheckbox.jsx
+++ b/frontend/src/components/input/RadioAsCheckbox.jsx
@@ -25,7 +25,7 @@ export default function RadioAsCheckbox({
             onChange={handleChange}
           />
           <span className={styles.checkmark}></span>
-          {item.label}
+          <span className={styles.labelText}>{item.label}</span>
         </label>
       ))}
     </div>

--- a/frontend/src/components/input/inputs.module.scss
+++ b/frontend/src/components/input/inputs.module.scss
@@ -96,6 +96,10 @@
         box-sizing: border-box;
     }
 
+    .customRadio .labelText {
+        margin-left: 0.25rem;
+    }
+
     .customRadio input[type="radio"]:checked+.checkmark::after {
         content: '';
         position: absolute;

--- a/frontend/src/pages/dashboard/suggestion/FullView.jsx
+++ b/frontend/src/pages/dashboard/suggestion/FullView.jsx
@@ -158,13 +158,19 @@ const SuggestionContent = ({ suggestion, role }) => {
 }
 
 
-const Revs = ({suggestion }) => {
+const Revs = ({ suggestion }) => {
     const { reviewers, assign } = useAssociateEditor()
 
-    const options = reviewers.map(item => ({
-        label: item.name,
-        value: item.id
-    }))
+    const assigned = Array.isArray(suggestion.assignedReviewers)
+        ? suggestion.assignedReviewers.map(r => r.id)
+        : []
+
+    const options = reviewers
+        .filter(item => !assigned.includes(item.id))
+        .map(item => ({
+            label: item.name,
+            value: item.id
+        }))
 
 
     return (


### PR DESCRIPTION
## Summary
- keep label text next to custom radio in `RadioAsCheckbox`
- tweak styles so radio text aligns with checkbox
- filter already assigned reviewers in `FullView` before displaying options

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c5a7dbe8832da82857224d333f4b