### PR TITLE
Finalize board suggestions workflow

### DIFF
--- a/backend/src/controllers/suggestion/index.js
+++ b/backend/src/controllers/suggestion/index.js
@@ -12,6 +12,7 @@ import { postChangeRequest } from './post-change.js'
 import { postDeferral } from './post-deferral.js'
 import { postRecommednation } from './post-recommendation.js'
 import { postDiscussion } from './post-discussion.js'
+import { postImplementation } from './post-implementation.js'
 
 export {
     postSuggestion,
@@ -25,5 +26,6 @@ export {
     postChangeRequest,
     postDeferral,
     postRecommednation,
-    postDiscussion
+    postDiscussion,
+    postImplementation
 };

--- a/backend/src/controllers/suggestion/post-implementation.js
+++ b/backend/src/controllers/suggestion/post-implementation.js
@@ -1,0 +1,23 @@
+const { finalizeImplementation } = require('@services/suggestion');
+const { AppError } = require('@errors');
+const logger = require('@logger').addSource({ file: 'suggestion.controller', method: 'postImplementation' });
+
+const postImplementation = async (req, res) => {
+    try {
+        logger.start('POST Implementation');
+        const { id } = req.params;
+        const { eicId, notes, message } = req.body;
+        await finalizeImplementation(id, eicId, notes, message);
+        logger.success('suggestion.implemented');
+        return res.status(200).json({ success: true });
+    } catch (error) {
+        if (!(error instanceof AppError)) {
+            logger.error(error.stack);
+        }
+        return res.status(error.statusCode || 500).json({ success: false, message: error.publicMessage || 'Internal Server Error' });
+    } finally {
+        logger.end('POST Implementation');
+    }
+};
+
+module.exports = { postImplementation };

--- a/backend/src/models/suggestion/suggestion.model.js
+++ b/backend/src/models/suggestion/suggestion.model.js
@@ -243,6 +243,22 @@ class Suggestion {
                 'for_editor_in_chief': Status.Private.STARTED_DISCUSSION,
                 'system': Status.System.IN_FINAL_PHASE
             }
+                break;
+
+            case Actions.ACCEPTED_BY_BOARD: this.status = {
+                'for_member': Status.Public.ACCEPTED,
+                'for_associate_editor': Status.Private.APPROVED,
+                'for_editor_in_chief': Status.Private.APPROVED,
+                'system': Status.System.CLOSED
+            }
+                break;
+
+            case Actions.DECLINED_BY_BOARD: this.status = {
+                'for_member': Status.Public.REJECTED,
+                'for_associate_editor': Status.Private.REJECTED,
+                'system': Status.System.CLOSED
+            }
+                break;
         }
     }
 
@@ -460,6 +476,26 @@ class Suggestion {
         } else {
             return { updated: false, message: 'User not found' };
         }
+    }
+
+    finalizeIfComplete() {
+        const votes = this.final_decisions.map(d => d.final_decision);
+        if (votes.includes('pending')) return null;
+
+        if (votes.includes('exclude')) {
+            this._updateStatus(Actions.DECLINED_BY_BOARD);
+            this.insertHistory(Actions.DECLINED_BY_BOARD, 'LiveC');
+            return 'declined';
+        }
+
+        this._updateStatus(Actions.ACCEPTED_BY_BOARD);
+        this.insertHistory(Actions.ACCEPTED_BY_BOARD, 'LiveC');
+        return 'accepted';
+    }
+
+    finalizeImplementation(eic, notes = '', message = '') {
+        this.insertDocumentation(Actions.ACCEPTED_BY_BOARD, eic, notes);
+        this.insertPublicMessage(message, eic);
     }
 }
 

--- a/backend/src/routes/suggestion.routes.js
+++ b/backend/src/routes/suggestion.routes.js
@@ -4,7 +4,7 @@ const {
     postSuggestion, postRejection, getSuggestion,
     postStartReview, postAssignReviewers, postDocumentation,
     postAssociateEditorFinalization, postEditorInChiefApproval,
-    postChangeRequest, postDeferral, postRecommednation, postDiscussion
+    postChangeRequest, postDeferral, postRecommednation, postDiscussion, postImplementation
 } = require('@controllers/suggestion/');
 
 const router = express.Router();
@@ -31,6 +31,7 @@ router.post('/:id/assign-reviewers', postAssignReviewers);
 
 router.post('/:id/post-recommendation', postRecommednation);
 router.post('/:id/start-discussion', postDiscussion);
+router.post('/:id/implement', postImplementation);
 
 
 

--- a/backend/src/services/suggestion/finalize-implementation.js
+++ b/backend/src/services/suggestion/finalize-implementation.js
@@ -1,0 +1,36 @@
+const { AppError, SuggestionNotFoundError } = require('@errors');
+const Suggestions = require('@models/suggestion/suggestions.model.js');
+const { updateCurriculumSection } = require('@services/curriculum');
+
+const logger = require('@logger').addSource({
+    file: 'suggestion.service',
+    method: 'finalizeImplementation',
+    params: ['suggestionId', 'eicId', 'notes', 'message']
+});
+
+const finalizeImplementation = async (id, eicId, notes, message) => {
+    try {
+        logger.debug('suggestion.implement.db.searching');
+        const suggestion = await Suggestions.findById(id);
+        if (!suggestion) throw new SuggestionNotFoundError();
+
+        suggestion.finalizeImplementation(eicId, notes, message);
+        await updateCurriculumSection(suggestion.discipline, {
+            id: suggestion.section_id,
+            content: suggestion.revised_section,
+        });
+
+        await Suggestions.update(suggestion);
+        logger.debug('suggestion.implement.finished');
+        return true;
+    } catch (error) {
+        if (!(error instanceof AppError)) {
+            logger.error(error.stack);
+        } else {
+            logger.warn(error.message, { err: error.errorCode });
+        }
+        throw error;
+    }
+};
+
+module.exports = finalizeImplementation;

--- a/backend/src/services/suggestion/index.js
+++ b/backend/src/services/suggestion/index.js
@@ -1,19 +1,19 @@
-const linkCommunityMemberToSuggestion = require('./link-user')
-const assignAssociateEditorToSuggestion = require('./assign-editor')
-const handleRejectSuggestion = require('./handle-reject')
-const handleNewSuggestion = require('./handle-suggestion')
-const getSuggestionById = require('./get-one')
-const handleStartSuggestionReviewProcess = require('./handle-start')
-const assignReviewersToSuggestion = require('./assign-reviewers')
-const addNewDocumentationToSuggestion = require('./add-documentation')
-const associateEditorFinalized = require('./finalize')
-const handleEditorInChiefApproval = require('./handle-approval')
-const sendChangeRequestToAssociateEditor = require('./send-change')
-const handleDeferSuggestionToReviewer = require('./handle-deferral')
-const addRecommendationFromReviewer = require('./handle-recommendation')
-const handleFinalDiscussion = require('./handle-discussion')
-const updateVote = require('./update-vote')
-
+const linkCommunityMemberToSuggestion = require('./link-user');
+const assignAssociateEditorToSuggestion = require('./assign-editor');
+const handleRejectSuggestion = require('./handle-reject');
+const handleNewSuggestion = require('./handle-suggestion');
+const getSuggestionById = require('./get-one');
+const handleStartSuggestionReviewProcess = require('./handle-start');
+const assignReviewersToSuggestion = require('./assign-reviewers');
+const addNewDocumentationToSuggestion = require('./add-documentation');
+const associateEditorFinalized = require('./finalize');
+const handleEditorInChiefApproval = require('./handle-approval');
+const sendChangeRequestToAssociateEditor = require('./send-change');
+const handleDeferSuggestionToReviewer = require('./handle-deferral');
+const addRecommendationFromReviewer = require('./handle-recommendation');
+const handleFinalDiscussion = require('./handle-discussion');
+const updateVote = require('./update-vote');
+const finalizeImplementation = require('./finalize-implementation');
 
 module.exports = {
     handleRejectSuggestion,
@@ -28,5 +28,6 @@ module.exports = {
     handleDeferSuggestionToReviewer,
     addRecommendationFromReviewer,
     handleFinalDiscussion,
-    updateVote
-}
+    updateVote,
+    finalizeImplementation,
+};

--- a/backend/src/services/suggestion/update-vote.js
+++ b/backend/src/services/suggestion/update-vote.js
@@ -1,8 +1,6 @@
-const { AppError, SuggestionNotFoundError, NoUserWithIdError } = require('@errors');
+const { AppError, SuggestionNotFoundError } = require('@errors');
 const Suggestions = require('@models/suggestion/suggestions.model.js')
-// import Suggestions from '@models/suggestion/suggestions.model.js';
-const EditorsInChief = require('@models/users/editor-in-chief/chiefs.model');
-const { child } = require('winston');
+const { updateCurriculumSection } = require('@services/curriculum');
 
 const logger = require('@logger').addSource({
     file: 'suggestion.service',
@@ -33,7 +31,22 @@ const updateVote = async ({ id, userId, formData }) => {
             }
         ]
 
-        suggestionToVoteOn.updateVote(userId, decision, content)
+        if (suggestionToVoteOn.didVote(userId)) {
+            logger.debug('suggestion.already.voted')
+        } else {
+            suggestionToVoteOn.updateVote(userId, decision, content)
+
+            const result = suggestionToVoteOn.finalizeIfComplete()
+            if (result === 'accepted') {
+                await updateCurriculumSection(
+                    suggestionToVoteOn.discipline,
+                    {
+                        id: suggestionToVoteOn.section_id,
+                        content: suggestionToVoteOn.revised_section,
+                    }
+                )
+            }
+        }
 
         const ups = await Suggestions.update(suggestionToVoteOn)
         const didVote = ups.didVote(userId)

--- a/backend/src/utils/constants/index.js
+++ b/backend/src/utils/constants/index.js
@@ -27,7 +27,9 @@ const Actions = Object.freeze({
     APPROVED_BY_EDITOR_IN_CHIEF: 'approved-by-editor-in-chief',
     CHANGE_REQUEST_BY_EDITOR_IN_CHIEF: 'change-request-by-editor-in-chief',
     REJECTED_BY_EDITOR_IN_CHIEF: 'rejected-by-editor-in-chief',
-    STARTED_FINAL_DISCUSSION: 'started-final-discussion'
+    STARTED_FINAL_DISCUSSION: 'started-final-discussion',
+    ACCEPTED_BY_BOARD: 'accepted-by-board',
+    DECLINED_BY_BOARD: 'declined-by-board'
 })
 
 

--- a/frontend/src/pages/dashboard/board/FinalView.jsx
+++ b/frontend/src/pages/dashboard/board/FinalView.jsx
@@ -12,7 +12,7 @@ import { BackButton, Button } from '@components/buttons';
 import styles from '../suggestion/SuggestionView.module.scss';
 import { FlexColumn, FlexRow, Container } from '@components/layouts/flex';
 import Page from '@features/details/Page';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import io from 'socket.io-client';
 
 export default function FinalView({ suggestion, user }) {
@@ -120,6 +120,7 @@ const SuggestionContent = ({ suggestion, user }) => {
         // setStatusCounts(counts);
     };
     const socket = io('http://localhost:3000');
+    const [current, setCurrent] = useState(suggestion);
     const [votes, setVotes] = useState(handleVotes(suggestion?.finalDecisions));
     const options = [
         { label: 'Include', value: 'include' },
@@ -128,6 +129,7 @@ const SuggestionContent = ({ suggestion, user }) => {
 
     useEffect(() => {
         socket.on('update', (newVotes) => {
+            setCurrent(newVotes);
             setVotes(handleVotes(newVotes?.finalDecisions));
         });
 
@@ -149,20 +151,24 @@ const SuggestionContent = ({ suggestion, user }) => {
                 <h3>Exclude: {votes.exclude}</h3>
                 <h3>Include: {votes.include}</h3>
                 <h3>Undecided: {votes.pending}</h3>
-                {!suggestion?.voted && (
+                {!current?.voted && (
                     <Form
                         //  showConfirmation={{
                         //      defaultInfo: <RecModal />,
                         //      successInfo: <></>,
                         //  }}
                         onSubmit={(formData) =>
-                            handleVote(suggestion.id, formData)
+                            handleVote(current.id, formData)
                         }
                     >
                         <RadioAsCheckbox keyName="decision" options={options} />
                         <TextArea keyName="notes" label="Notes" />
                     </Form>
                 )}
+                {current?.status?.for_member === Status.Public.ACCEPTED &&
+                    user.isEditorInChief && (
+                        <ImplementationForm suggestion={current} />
+                    )}
             </SideContent>
         </SubGrid>
     );
@@ -174,6 +180,8 @@ import useView from '@hooks/useView';
 import { Form, RadioAsCheckbox, TextArea } from '@components/input';
 import useReviewer from '@features/reviewer/useReviewer';
 import Documentation from '@features/document/Documentation';
+import { postImplementation } from '@utils/api-handlers/suggestions';
+import { UserContext } from '@context/UserProvider';
 const SectionView = ({ suggestion, rev }) => {
     const { currentView, setView } = useView('current');
     return (
@@ -201,5 +209,29 @@ const SectionView = ({ suggestion, rev }) => {
 
             <Container colSpan={1} rowSpan={9}></Container>
         </SubGrid>
+    );
+};
+
+const ImplementationForm = ({ suggestion }) => {
+    const { user } = useContext(UserContext);
+    const [done, setDone] = useState(false);
+
+    if (done) return <p>Update sent.</p>;
+
+    return (
+        <Form
+            onSubmit={async (data) => {
+                await postImplementation(
+                    suggestion.id,
+                    user.id,
+                    data.forPrivate,
+                    data.forPublic
+                );
+                setDone(true);
+            }}
+        >
+            <TextArea keyName="forPrivate" label="Message to submitter" />
+            <TextArea keyName="forPublic" label="Public update" />
+        </Form>
     );
 };

--- a/frontend/src/utils/api-handlers/suggestions/index.js
+++ b/frontend/src/utils/api-handlers/suggestions/index.js
@@ -11,3 +11,4 @@ export * from './post-deferral';
 export * from './post-recommendation';
 export * from './post-discussion';
 export * from './post-decision';
+export * from './post-implementation';

--- a/frontend/src/utils/api-handlers/suggestions/post-implementation.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-implementation.js
@@ -1,0 +1,13 @@
+import { API } from '@api/client.js';
+import { logger } from '@utils/logger';
+
+const log = logger.create('postImplementation.js');
+
+export const postImplementation = async (id, eicId, notes, message) => {
+    try {
+        await API.post(`/suggestion/${id}/implement`, { eicId, notes, message });
+        log.success('implementation.submitted');
+    } catch (error) {
+        log.error(error);
+    }
+};


### PR DESCRIPTION
## Summary
- add board decision constants
- update suggestion model for board decision logic
- prevent duplicate board votes and close suggestion when done
- support final implementation service and controller
- expose new API on frontend for implementation
- show finalize button in FinalView for the EIC

## Testing
- `npm run docs` *(fails: jsdoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856aff6b18832db2ec02d95714e38d