### PR TITLE
Remove console logs from API handlers

### DIFF
--- a/frontend/src/utils/api-handlers/suggestions/post-approval.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-approval.js
@@ -17,7 +17,7 @@ const log = logger.create('postSuggestion.js');
  */
 export const postEditorInChiefApproval = async (id, eicId, notes, message) => {
     try {
-        console.log(id, eicId, notes, message);
+        log.debug('EIC approval', id, eicId, notes, message);
         await API.post(`/suggestion/${id}/approve`, { eicId, notes, message });
     } catch (error) {
         log.error(error);

--- a/frontend/src/utils/api-handlers/suggestions/post-change.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-change.js
@@ -16,7 +16,7 @@ const log = logger.create('postSuggestion.js');
  */
 export const postChangeRequest = async (id, eic, change) => {
     try {
-        console.log(id, eic, change);
+        log.debug('Change request', id, eic, change);
         await API.post(`/suggestion/${id}/change-request`, { eic, change });
     } catch (error) {
         log.error(error);

--- a/frontend/src/utils/api-handlers/suggestions/post-decision.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-decision.js
@@ -14,7 +14,7 @@ const log = logger.create('postDiscussion.js');
  */
 export const postDecision = async (id, eicId,) => {
     try {
-        console.log(id, eicId);
+        log.debug('Decision posted', id, eicId);
         await API.post(`/suggestion/${id}/start-discussion`, { eicId });
     } catch (error) {
         log.error(error);

--- a/frontend/src/utils/api-handlers/suggestions/post-discussion.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-discussion.js
@@ -14,7 +14,7 @@ const log = logger.create('postDiscussion.js');
  */
 export const postDiscussion = async (id, eicId,) => {
     try {
-        console.log(id, eicId);
+        log.debug('Start discussion', id, eicId);
         await API.post(`/suggestion/${id}/start-discussion`, { eicId });
     } catch (error) {
         log.error(error);

--- a/frontend/src/utils/api-handlers/suggestions/post-reviewers.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-reviewers.js
@@ -1,6 +1,8 @@
 import { API } from '@api/client.js';
 import { logger } from '@utils/logger';
 
+const log = logger.create('postAssignReviewers.js');
+
 /**
  * Assigns one or more reviewers to a suggestion.
  *
@@ -14,7 +16,7 @@ import { logger } from '@utils/logger';
  */
 export const postAssignReviewers = async (suggestionId, reviewers) => {
     try {
-        console.log('hand:', suggestionId, reviewers);
+        log.debug('Assigning reviewers', suggestionId, reviewers);
         await API.post(`/suggestion/${suggestionId}/assign-reviewers `, {
             reviewers,
         });

--- a/frontend/src/utils/api-handlers/suggestions/post-suggestion.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-suggestion.js
@@ -25,7 +25,7 @@ export const postSuggestion = async (
     sectionId
 ) => {
     try {
-        console.log({
+        log.debug('Submitting suggestion', {
             userId,
             title,
             suggestion,


### PR DESCRIPTION
## Summary
- replace direct `console.log` calls in suggestion api handlers with `logger` debug calls
- add per-file log instance for assigning reviewers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68858d833b34832d99a6ecb1944587c0