### PR TITLE
Add skeleton loading for CurriculumDetails

### DIFF
--- a/frontend/src/features/details/useTableOfContents.jsx
+++ b/frontend/src/features/details/useTableOfContents.jsx
@@ -13,11 +13,13 @@ export default function useTableOfContents(curriculum) {
 
     /** @type {[Section, Function]} */
     const [currentPage, setCurrentPage] = useState();
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
+        setLoading(true);
         getCurriculum(curriculum)
             .then((res) => {
-                if (res.length > 0) {
+                if (Array.isArray(res) && res.length > 0) {
                     // Modify the first item
                     res[0] = {
                         ...res[0],
@@ -29,11 +31,14 @@ export default function useTableOfContents(curriculum) {
                         ...res[res.length - 1],
                         isLast: true,
                     };
-                }
 
-                setTableOfContents(res);
+                    setTableOfContents(res);
+                } else {
+                    setTableOfContents([]);
+                }
             })
-            .catch(console.error);
+            .catch(() => setTableOfContents([]))
+            .finally(() => setLoading(false));
     }, [curriculum]);
 
     useEffect(() => {
@@ -68,5 +73,6 @@ export default function useTableOfContents(curriculum) {
         previousPage,
         currentPage,
         setCurrentPage,
+        loading,
     };
 }

--- a/frontend/src/pages/Details/CurriculumDetailsPage.jsx
+++ b/frontend/src/pages/Details/CurriculumDetailsPage.jsx
@@ -6,12 +6,12 @@ import PdfView from '@features/details/PdfView.jsx';
 import Breadcrumbs from '@components/BreadCrumbs';
 import SuggestionBox from '@components/SuggestionBox';
 import useTableOfContents from '@features/details/useTableOfContents';
-import { Disciplines } from '@utils/constants';
 import { FlexColumn, FlexRow } from '@components/layouts/flex';
 import { Button } from '@components/buttons';
 import TableOfContents from '@features/details/TableOfContents';
 import { PublicForum } from '@features/details/Forum';
 import { toTitleCase } from '@utils/format';
+import CurriculumDetailsSkeleton from './CurriculumDetailsSkeleton.jsx';
 
 export default function CurriculumDetailsPage({
     selectedCurriculum = sessionStorage.getItem('curriculum'),
@@ -22,12 +22,17 @@ export default function CurriculumDetailsPage({
         tableOfContents,
         previousPage,
         setCurrentPage,
+        loading,
     } = useTableOfContents(selectedCurriculum);
 
     const [showPdf, setShowPdf] = useState(false);
 
+    if (loading) return <CurriculumDetailsSkeleton />;
+
     if (tableOfContents.length <= 0 || !currentPage)
-        return <h1>We working on it</h1>;
+        return (
+            <CurriculumDetailsSkeleton message="This curriculum is currently not implemented..." />
+        );
 
     return (
         <div className="details-page">

--- a/frontend/src/pages/Details/CurriculumDetailsSkeleton.jsx
+++ b/frontend/src/pages/Details/CurriculumDetailsSkeleton.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FlexColumn } from '@components/layouts/flex';
+
+export default function CurriculumDetailsSkeleton({ message }) {
+    const placeholderItems = Array.from({ length: 6 });
+    return (
+        <div className="details-page">
+            <aside className="toc-sidebar space-y-2 animate-pulse">
+                <div className="h-4 bg-gray-300 rounded w-3/4" />
+                <ul className="table-of-contents space-y-2 mt-4">
+                    {placeholderItems.map((_, idx) => (
+                        <li key={idx} className="toc-item">
+                            <div className="h-3 bg-gray-300 rounded" />
+                        </li>
+                    ))}
+                </ul>
+            </aside>
+            <FlexColumn className="pdf-container gap-4 items-center justify-center">
+                {message && (
+                    <p className="text-center text-gray-600">{message}</p>
+                )}
+                <div className="w-11/12 h-6 bg-gray-300 rounded" />
+                <div className="w-11/12 h-96 bg-gray-200 rounded" />
+            </FlexColumn>
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add skeleton component for curriculum details
- handle loading state and missing curriculum in useTableOfContents
- show skeleton in CurriculumDetailsPage when loading or curriculum missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6885a6fe2108832d8c72ce2c390086e5