### PR TITLE
Add version history tab

### DIFF
--- a/frontend/src/features/details/VersionHistory.jsx
+++ b/frontend/src/features/details/VersionHistory.jsx
@@ -1,0 +1,25 @@
+import { FlexColumn } from '@components/layouts/flex';
+
+export default function VersionHistory({ meta }) {
+    if (!meta) return null;
+    const { year_version, section_version, previous_versions = [] } = meta;
+
+    return (
+        <FlexColumn gap="0.5rem">
+            <h2>Version History</h2>
+            <p>
+                <strong>Current Version:</strong>{' '}
+                {section_version || 'N/A'} {year_version ? `(${year_version})` : ''}
+            </p>
+            {previous_versions.length > 0 ? (
+                <ul>
+                    {previous_versions.map((ver) => (
+                        <li key={ver}>{ver}</li>
+                    ))}
+                </ul>
+            ) : (
+                <p>No previous versions available.</p>
+            )}
+        </FlexColumn>
+    );
+}

--- a/frontend/src/pages/Details/CurriculumDetailsPage.jsx
+++ b/frontend/src/pages/Details/CurriculumDetailsPage.jsx
@@ -1,6 +1,6 @@
 import './CurriculumDetailsPage.scss';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Page from '@features/details/Page.jsx';
 import PdfView from '@features/details/PdfView.jsx';
 import Breadcrumbs from '@components/BreadCrumbs';
@@ -12,6 +12,7 @@ import TableOfContents from '@features/details/TableOfContents';
 import { PublicForum } from '@features/details/Forum';
 import { toTitleCase } from '@utils/format';
 import CurriculumDetailsSkeleton from './CurriculumDetailsSkeleton.jsx';
+import VersionHistory from '@features/details/VersionHistory.jsx';
 
 export default function CurriculumDetailsPage({
     selectedCurriculum = sessionStorage.getItem('curriculum'),
@@ -26,6 +27,11 @@ export default function CurriculumDetailsPage({
     } = useTableOfContents(selectedCurriculum);
 
     const [showPdf, setShowPdf] = useState(false);
+    const [tab, setTab] = useState('content');
+
+    useEffect(() => {
+        setTab('content');
+    }, [currentPage]);
 
     if (loading) return <CurriculumDetailsSkeleton />;
 
@@ -76,10 +82,28 @@ export default function CurriculumDetailsPage({
                                 {currentPage?.meta.parent_heading ||
                                     currentPage?.title}
                             </h1>
+                            <FlexRow gap="0.5rem" className="tab-buttons">
+                                <Button
+                                    variant="round"
+                                    isActive={tab === 'content'}
+                                    onClick={() => setTab('content')}
+                                    text="Section"
+                                />
+                                <Button
+                                    variant="round"
+                                    isActive={tab === 'history'}
+                                    onClick={() => setTab('history')}
+                                    text="Versions"
+                                />
+                            </FlexRow>
                             <hr style={{ color: 'black', width: '100%' }} />
                         </div>
                         <FlexColumn padding={'2.5%'} gap="1.5rem">
-                            <Page page={currentPage} />
+                            {tab === 'content' ? (
+                                <Page page={currentPage} />
+                            ) : (
+                                <VersionHistory meta={currentPage?.meta} />
+                            )}
                             <FlexRow
                                 justify="space-between"
                                 style={{ width: '100%' }}

--- a/frontend/src/pages/Details/CurriculumDetailsPage.scss
+++ b/frontend/src/pages/Details/CurriculumDetailsPage.scss
@@ -90,6 +90,10 @@
     justify-content: space-between;
 }
 
+.tab-buttons {
+    margin-top: 0.5rem;
+}
+
 .page-number {
     font-size: 0.875rem;
     color: #718096;


### PR DESCRIPTION
## Summary
- add new `VersionHistory` component
- add section/version tab to CurriculumDetails page
- reset tab when section changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885aa6d8e18832d828c41c4ce802ef9