### PR TITLE
Display curriculum version details

### DIFF
--- a/backend/src/controllers/curriculum/get-version.js
+++ b/backend/src/controllers/curriculum/get-version.js
@@ -1,0 +1,28 @@
+const { getCurriculumVersion } = require('@services/curriculum');
+const { AppError } = require('@errors');
+const logger = require('@logger').addSource({ file: 'curriculum.controller', method: 'getVersion' });
+
+const getVersion = async (req, res) => {
+    try {
+        logger.start('GET Curriculum Version');
+        const { curriculum, versionId } = req.params;
+        const version = await getCurriculumVersion(curriculum, versionId);
+        if (!version) {
+            const error = new AppError('Version not found', 404, 'VERSION_NOT_FOUND');
+            throw error;
+        }
+        logger.success('curriculum.version.found');
+        return res.status(200).json({ success: true, version });
+    } catch (error) {
+        if (!(error instanceof AppError)) {
+            logger.error(error.stack);
+        } else {
+            logger.info(error.message, { err: error.errorCode });
+        }
+        return res.status(error.statusCode || 500).json({ success: false, message: error.publicMessage || 'Internal Server Error' });
+    } finally {
+        logger.end('GET Curriculum Version');
+    }
+};
+
+module.exports = { getVersion };

--- a/backend/src/controllers/curriculum/index.js
+++ b/backend/src/controllers/curriculum/index.js
@@ -2,5 +2,6 @@ const { getCurriculum } = require('./get-curriculum')
 const { getSection } = require('./get-section')
 const { updateSection } = require('./update-section')
 const { postVersion } = require('./post-version')
+const { getVersion } = require('./get-version')
 
-module.exports = { getCurriculum, getSection, updateSection, postVersion }
+module.exports = { getCurriculum, getSection, updateSection, postVersion, getVersion }

--- a/backend/src/models/curriculum/versions.model.js
+++ b/backend/src/models/curriculum/versions.model.js
@@ -9,6 +9,12 @@ class CurriculumVersions {
         return this.dbRef[curriculum].data.map(v => new CurriculumVersion(v));
     }
 
+    static async getById(curriculum, id) {
+        await this.dbRef[curriculum].read();
+        const found = this.dbRef[curriculum].data.find(v => v.id === id);
+        return found ? new CurriculumVersion(found) : null;
+    }
+
     static async insert(curriculum, data) {
         const version = new CurriculumVersion(data).toObject();
         await this.dbRef[curriculum].read();

--- a/backend/src/routes/curriculum.routes.js
+++ b/backend/src/routes/curriculum.routes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getCurriculum, getSection, updateSection, postVersion } = require('@controllers/curriculum')
+const { getCurriculum, getSection, updateSection, postVersion, getVersion } = require('@controllers/curriculum')
 
 const router = express.Router();
 
@@ -8,5 +8,6 @@ router.get('/:curriculum', getCurriculum);
 router.get('/:curriculum/sections/:sectionId', getSection);
 router.put('/:curriculum/sections/:sectionId', updateSection);
 router.post('/:curriculum/versions', postVersion);
+router.get('/:curriculum/versions/:versionId', getVersion);
 
 module.exports = router;

--- a/backend/src/services/curriculum/get-version.js
+++ b/backend/src/services/curriculum/get-version.js
@@ -1,0 +1,7 @@
+const CurriculumVersions = require('@models/curriculum/versions.model');
+
+const getCurriculumVersion = async (curriculum, versionId) => {
+    return CurriculumVersions.getById(curriculum, versionId);
+};
+
+module.exports = getCurriculumVersion;

--- a/backend/src/services/curriculum/index.js
+++ b/backend/src/services/curriculum/index.js
@@ -2,10 +2,12 @@ const getFullCurriculum = require('./get-one');
 const getCurriculumSection = require('./get-section');
 const updateCurriculumSection = require('./update-section');
 const addCurriculumVersion = require('./add-version');
+const getCurriculumVersion = require('./get-version');
 
 module.exports = {
     getFullCurriculum,
     getCurriculumSection,
     updateCurriculumSection,
-    addCurriculumVersion
+    addCurriculumVersion,
+    getCurriculumVersion
 };

--- a/frontend/src/features/details/VersionHistory.jsx
+++ b/frontend/src/features/details/VersionHistory.jsx
@@ -1,8 +1,28 @@
+import { useEffect, useState } from 'react';
 import { FlexColumn } from '@components/layouts/flex';
+import { getVersion } from '@utils/api-handlers/curriculums/get-version';
 
 export default function VersionHistory({ meta }) {
     if (!meta) return null;
-    const { year_version, section_version, previous_versions = [] } = meta;
+    const { year_version, section_version, previous_versions = [], curriculum } = meta;
+    const [versions, setVersions] = useState([]);
+
+    useEffect(() => {
+        if (previous_versions.length > 0 && curriculum) {
+            Promise.all(previous_versions.map((id) => getVersion(curriculum, id)))
+                .then((res) => setVersions(res.filter(Boolean)))
+                .catch(() => setVersions([]));
+        }
+    }, [previous_versions, curriculum]);
+
+    const renderContent = (content = []) =>
+        content
+            .map((block) =>
+                Array.isArray(block.children)
+                    ? block.children.map((ch) => ch.text || '').join('')
+                    : ''
+            )
+            .join(' ');
 
     return (
         <FlexColumn gap="0.5rem">
@@ -11,10 +31,16 @@ export default function VersionHistory({ meta }) {
                 <strong>Current Version:</strong>{' '}
                 {section_version || 'N/A'} {year_version ? `(${year_version})` : ''}
             </p>
-            {previous_versions.length > 0 ? (
+            {versions.length > 0 ? (
                 <ul>
-                    {previous_versions.map((ver) => (
-                        <li key={ver}>{ver}</li>
+                    {versions.map((ver) => (
+                        <li key={ver.id}>
+                            <p>
+                                <strong>{ver.section_version}</strong>{' '}
+                                {ver.meta.year_version ? `(${ver.meta.year_version})` : ''}
+                            </p>
+                            <p>{renderContent(ver.content)}</p>
+                        </li>
                     ))}
                 </ul>
             ) : (

--- a/frontend/src/utils/api-handlers/curriculums/get-version.js
+++ b/frontend/src/utils/api-handlers/curriculums/get-version.js
@@ -1,0 +1,11 @@
+import { API } from '@api/client.js';
+import { apiLog as log } from '../apiLogger';
+
+export const getVersion = async (curriculum, versionId) => {
+    try {
+        const { data } = await API.get(`/curriculums/${curriculum}/versions/${versionId}`);
+        return data.version;
+    } catch (error) {
+        log.error(error);
+    }
+};


### PR DESCRIPTION
## Summary
- implement endpoint to retrieve curriculum version by ID
- provide service and controller logic for new endpoint
- fetch version data for curriculum sections in the frontend
- show version info on the Versions tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885b8215ea8832db36da063c8d4df80