### PR TITLE
Improve logger and backend debug messages

### DIFF
--- a/backend/logger/logger.js
+++ b/backend/logger/logger.js
@@ -151,8 +151,16 @@ baseLogger.addSeparator = function (label = '', options = {}) {
 };
 
 // Add `.addSource()` method that returns a scoped child logger
-baseLogger.addSource = function (source, ini) {
-    return this.child({ source }, ini);
+// Create a scoped child logger that automatically tags the log source
+// with file/method context. Additional metadata can be passed via the
+// optional second argument.
+baseLogger.addSource = function (opts = {}, meta = {}) {
+    if (typeof opts === 'string') {
+        return this.child({ source: opts, ...meta });
+    }
+    const { file = '', method = '', params = [] } = opts;
+    const source = { file, method, params };
+    return this.child({ source, ...meta });
 };
 
 

--- a/backend/src/services/suggestion/add-documentation.js
+++ b/backend/src/services/suggestion/add-documentation.js
@@ -10,19 +10,19 @@ const logger = require('@logger').addSource({
 
 
 const addNewDocumentationToSuggestion = async (suggestionId, author, markdownText) => {
-try {
-
-        logger.debug("suggestion.add_docs.db.searching")
+    try {
+        logger.debug("suggestion.add_docs.db.searching", { suggestionId, author })
 
         const suggestionToAddDocumentation = await Suggestions.findById(suggestionId)
 
         if (!suggestionToAddDocumentation) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.add_docs.db.found")
 
         logger.debug("suggestion.add_docs.starting")
         suggestionToAddDocumentation.insertDocumentation(null, author, markdownText)
-        Suggestions.update(suggestionToAddDocumentation)
+        await Suggestions.update(suggestionToAddDocumentation)
         logger.debug("suggestion.add_docs.finished")
 
 

--- a/backend/src/services/suggestion/assign-reviewers.js
+++ b/backend/src/services/suggestion/assign-reviewers.js
@@ -13,25 +13,23 @@ const assignReviewersToSuggestion = async (suggestionId, reviewers) => {
 
     try {
 
-        logger.debug("suggestion.assign_reviewers.db.searching")
+        logger.debug("suggestion.assign_reviewers.db.searching", { suggestionId, reviewers })
         const suggestionToAddReviewers = await Suggestions.findById(suggestionId);
-
 
         if (!suggestionToAddReviewers) {
             throw new SuggestionNotFoundError
         }
-
         logger.debug("suggestion.assign_reviewers.db.found")
 
 
         logger.debug("suggestion.assign_reviewers.db.inserting")
 
-        suggestionToAddReviewers.assignReviewers( reviewers)
+        suggestionToAddReviewers.assignReviewers(reviewers)
         await Suggestions.update(suggestionToAddReviewers)
 
         logger.debug("suggestion.assign_reviewers.db.inserted")
 
-        linkSuggestionToReviewers(suggestionId, reviewers)
+        await linkSuggestionToReviewers(suggestionId, reviewers)
 
 
     } catch (error) {

--- a/backend/src/services/suggestion/finalize-implementation.js
+++ b/backend/src/services/suggestion/finalize-implementation.js
@@ -10,15 +10,19 @@ const logger = require('@logger').addSource({
 
 const finalizeImplementation = async (id, eicId, notes, message) => {
     try {
-        logger.debug('suggestion.implement.db.searching');
+        logger.debug('suggestion.implement.db.searching', { id, eicId });
         const suggestion = await Suggestions.findById(id);
         if (!suggestion) throw new SuggestionNotFoundError();
+        logger.debug('suggestion.implement.db.found');
 
+        logger.debug('suggestion.implement.starting');
         suggestion.finalizeImplementation(eicId, notes, message);
+        logger.debug('suggestion.implement.curriculum.updating');
         await updateCurriculumSection(suggestion.discipline, {
             id: suggestion.section_id,
             content: suggestion.revised_section,
         });
+        logger.debug('suggestion.implement.curriculum.updated');
 
         await Suggestions.update(suggestion);
         logger.debug('suggestion.implement.finished');

--- a/backend/src/services/suggestion/finalize.js
+++ b/backend/src/services/suggestion/finalize.js
@@ -13,13 +13,14 @@ const logger = require('@logger').addSource({
 const associateEditorFinalized = async (suggestionId, associateEditor, updatedSection) => {
 try {
 
-        logger.debug("suggestion.finalize.db.searching")
+        logger.debug("suggestion.finalize.db.searching", { suggestionId })
 
         const suggestionToFinalize = await Suggestions.findById(suggestionId)
 
         if (!suggestionToFinalize) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.finalize.db.found")
 
         logger.debug("suggestion.finalize.starting")
 
@@ -29,12 +30,13 @@ try {
         logger.debug("suggestion.finalize.finished")
 
         const eic = suggestionToFinalize.assigned_editor_in_chief
-
+        logger.debug("suggestion.finalize.notify.db.searching", { eic })
         const eicToNotify = await EditorsInChief.findById(eic)
 
         if (!eicToNotify) {
             throw new NoUserWithIdError
         }
+        logger.debug("suggestion.finalize.notify.db.found")
 
         eicToNotify.assignSuggestion(suggestionId)
 

--- a/backend/src/services/suggestion/get-one.js
+++ b/backend/src/services/suggestion/get-one.js
@@ -15,13 +15,15 @@ function kebabToCamel(str) {
 const getSuggestionById = async (suggestionId, role = null) => {
     try {
 
-        logger.debug("suggestion.get.db.searching")
+        logger.debug("suggestion.get.db.searching", { suggestionId })
 
         const requestedSuggestion = await Suggestions.findById(suggestionId)
-        let retS
+
         if (!requestedSuggestion) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.get.db.found")
+        let retS
 
 
 
@@ -40,16 +42,17 @@ const getSuggestionById = async (suggestionId, role = null) => {
 
         const curri = kebabToCamel(retS.discipline)
         const secId = retS.sectionId
+        logger.debug("suggestion.get.curriculum.searching", { curri })
         const c = await Curriculums.findByCurriculum(curri)
+        logger.debug("suggestion.get.curriculum.found")
 
+        logger.debug("suggestion.get.section.searching", { secId })
         const section = await c.getSection(secId)
-        logger.debug('suggestion.get.gett', { curri, secId })
-
-        logger.debug(JSON.stringify(section))
+        logger.debug("suggestion.get.section.found")
 
         logger.debug("suggestion.get.found")
 
-
+        logger.debug("suggestion.get.finished")
         return { ...retS, section }
 
     } catch (error) {

--- a/backend/src/services/suggestion/handle-approval.js
+++ b/backend/src/services/suggestion/handle-approval.js
@@ -11,15 +11,15 @@ const logger = require('@logger').addSource({
 
 
 const handleEditorInChiefApproval = async (id, eicId, notes, message) => {
-try {
-
-        logger.debug("suggestion.approve.db.searching")
+    try {
+        logger.debug("suggestion.approve.db.searching", { id, eicId })
 
         const suggestionToApprove = await Suggestions.findById(id)
 
         if (!suggestionToApprove) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.approve.db.found")
 
         logger.debug("suggestion.approve.starting")
 

--- a/backend/src/services/suggestion/handle-discussion.js
+++ b/backend/src/services/suggestion/handle-discussion.js
@@ -13,30 +13,30 @@ const logger = require('@logger').addSource({
 
 const handleFinalDiscussion = async (id, eicId) => {
     try {
-
-        logger.debug("suggestion.approve.db.searching")
+        logger.debug("suggestion.discussion.db.searching", { id, eicId })
 
         const suggestionToDiscuss = await Suggestions.findById(id)
 
         if (!suggestionToDiscuss) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.discussion.db.found")
 
-        logger.debug("suggestion.approve.starting")
+        logger.debug("suggestion.discussion.starting")
 
         suggestionToDiscuss.startDiscussion(eicId)
-        logger.debug("suggestion.approve.getc")
 
+        logger.debug("suggestion.discussion.chief.searching", { eicId })
         const chief = await EditorsInChief.findById(eicId)
+        logger.debug("suggestion.discussion.chief.found")
         const aes = chief.getAllAssociateEditors()
-        logger.debug("suggestion.approve.finished", { aes })
+        logger.debug("suggestion.discussion.board.preparing", { aes })
 
         const board = [eicId, ...aes]
-        logger.debug("suggestion.approve.got-board")
 
         suggestionToDiscuss.addBoard(board)
         await Suggestions.update(suggestionToDiscuss)
-        logger.debug("suggestion.approve.finished", { board })
+        logger.debug("suggestion.discussion.finished", { board })
 
 
         for (const aid of chief.getAllAssociateEditors()) {

--- a/backend/src/services/suggestion/handle-reject.js
+++ b/backend/src/services/suggestion/handle-reject.js
@@ -14,9 +14,9 @@ const handleRejectSuggestion = async (suggestionId, rejectedById, reason, messag
 
     try {
 
-        logger.debug("suggestion.reject.db.searching")
+        logger.debug("suggestion.reject.db.searching", { suggestionId })
         const suggestionToReject = await Suggestions.findById(suggestionId)
-
+        
         if (!suggestionToReject) {
             throw new SuggestionNotFoundError
         }

--- a/backend/src/services/suggestion/handle-start.js
+++ b/backend/src/services/suggestion/handle-start.js
@@ -10,17 +10,18 @@ const logger = require('@logger').addSource({
 const handleStartSuggestionReviewProcess = async (suggestionId, startedBy, notes, message) => {
 try {
 
-        logger.debug("suggestion.start_review.db.searching")
+        logger.debug("suggestion.start_review.db.searching", { suggestionId })
 
         const suggestionToStartReview = await Suggestions.findById(suggestionId)
 
         if (!suggestionToStartReview) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.start_review.db.found")
 
         logger.debug("suggestion.start_review.starting")
         const startId = suggestionToStartReview.startReview(startedBy, notes, message)
-        Suggestions.update(suggestionToStartReview)
+        await Suggestions.update(suggestionToStartReview)
         logger.debug("suggestion.start_review.started")
 
         return startId

--- a/backend/src/services/suggestion/handle-suggestion.js
+++ b/backend/src/services/suggestion/handle-suggestion.js
@@ -63,6 +63,7 @@ const addToCurriculum = async (suggestionId, sectionId, discipline) => {
         if (!requestedCurriculum) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("curriculum.get.db.found")
 
         const section = await requestedCurriculum.getSectionToc(sectionId)
 
@@ -74,6 +75,7 @@ const addToCurriculum = async (suggestionId, sectionId, discipline) => {
         }
 
         requestedCurriculum.updateToc(section)
+        logger.debug("curriculum.toc.updated", { sectionId })
     } catch (error) {
 
     }

--- a/backend/src/services/suggestion/link-user.js
+++ b/backend/src/services/suggestion/link-user.js
@@ -12,9 +12,10 @@ async function linkCommunityMemberToSuggestion(userId, suggestionId) {
 
     try {
 
-        logger.debug("suggestion.post.link_user.db.searching")
+        logger.debug("suggestion.post.link_user.db.searching", { userId, suggestionId })
         const submittedBy = await CommunityMembers.findById(userId);
         if (!submittedBy) throw NoUserWithIdError
+        logger.debug("suggestion.post.link_user.db.found")
 
         logger.debug("suggestion.post.link_user.db.linking")
         submittedBy.addSuggestion(suggestionId);

--- a/backend/src/services/suggestion/send-change.js
+++ b/backend/src/services/suggestion/send-change.js
@@ -14,13 +14,14 @@ const logger = require('@logger').addSource({
 const sendChangeRequestToAssociateEditor = async (suggestionId, eic, change) => {
 try {
 
-        logger.debug("suggestion.change.db.searching")
+        logger.debug("suggestion.change.db.searching", { suggestionId })
 
         const suggestionToSendChangeRequest = await Suggestions.findById(suggestionId)
 
         if (!suggestionToSendChangeRequest) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.change.db.found")
 
         logger.debug("suggestion.change.starting")
 

--- a/backend/src/services/suggestion/update-vote.js
+++ b/backend/src/services/suggestion/update-vote.js
@@ -13,16 +13,16 @@ const logger = require('@logger').addSource({
 const updateVote = async ({ id, userId, formData }) => {
     try {
 
-        logger.debug("suggestion.change.db.searching", { id, userId, formData })
+        logger.debug("suggestion.vote.db.searching", { id, userId })
         const { decision, notes } = formData
-        logger.debug("...", { decision, notes })
         const suggestionToVoteOn = await Suggestions.findById(id)
 
         if (!suggestionToVoteOn) {
             throw new SuggestionNotFoundError
         }
+        logger.debug("suggestion.vote.db.found")
 
-        logger.debug("suggestion.change.starting")
+        logger.debug("suggestion.vote.starting")
 
         const content = [
             {
@@ -45,7 +45,7 @@ const updateVote = async ({ id, userId, formData }) => {
         const ret = ups.toAssociateEditor()
         ret.voted = didVote
 
-        logger.debug("suggestion.change.finished")
+        logger.debug("suggestion.vote.finished")
         return ret
 
 


### PR DESCRIPTION
## Summary
- refine logger `addSource` to accept plain strings or option objects
- improve logging order and add detail for suggestion workflows
- await suggestion updates and note curriculum updates

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6885bbd1ae3c832d8b50adaae8530e0a