### PR TITLE
Centralize kebabToCamel util

### DIFF
--- a/backend/src/services/curriculum/get-one.js
+++ b/backend/src/services/curriculum/get-one.js
@@ -3,6 +3,7 @@ const { Roles } = require('@utils/constants')
 const AssociateEditors = require('@models/users/associate-editor/editors.model.js')
 const Suggestions = require('@models/suggestion/suggestions.model.js')
 const Curriculums = require('@models/curriculum/curriculums.model.js')
+const kebabToCamel = require('@utils/kebabToCamel')
 
 
 const logger = require('@logger').addSource({
@@ -11,9 +12,6 @@ const logger = require('@logger').addSource({
     params: ['suggestion']
 });
 
-function kebabToCamel(str) {
-    return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
-}
 
 
 const getFullCurriculum = async (curriculum) => {

--- a/backend/src/services/curriculum/get-section.js
+++ b/backend/src/services/curriculum/get-section.js
@@ -1,8 +1,5 @@
 const Curriculums = require('@models/curriculum/curriculums.model.js');
-
-function kebabToCamel(str) {
-    return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-}
+const kebabToCamel = require('@utils/kebabToCamel');
 
 const getCurriculumSection = async (curriculum, id) => {
     const curr = await Curriculums.findByCurriculum(kebabToCamel(curriculum));

--- a/backend/src/services/curriculum/update-section.js
+++ b/backend/src/services/curriculum/update-section.js
@@ -1,8 +1,5 @@
 const Curriculums = require('@models/curriculum/curriculums.model.js');
-
-function kebabToCamel(str) {
-    return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-}
+const kebabToCamel = require('@utils/kebabToCamel');
 
 const updateCurriculumSection = async (curriculum, section) => {
     const curr = await Curriculums.findByCurriculum(kebabToCamel(curriculum));

--- a/backend/src/services/suggestion/get-one.js
+++ b/backend/src/services/suggestion/get-one.js
@@ -2,15 +2,13 @@ const { AppError, NoAssociateEditorsFoundError, SuggestionNotFoundError } = requ
 const { Roles } = require('@utils/constants')
 const Suggestions = require('@models/suggestion/suggestions.model.js')
 const Curriculums = require('@models/curriculum/curriculums.model.js')
+const kebabToCamel = require('@utils/kebabToCamel')
 const logger = require('@logger').addSource({
     file: 'auth.service',
     method: "assignAssociateEditorToSuggestion",
     params: ['suggestion']
 });
 
-function kebabToCamel(str) {
-    return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
-}
 
 const getSuggestionById = async (suggestionId, role = null) => {
     try {

--- a/backend/src/services/suggestion/handle-suggestion.js
+++ b/backend/src/services/suggestion/handle-suggestion.js
@@ -1,6 +1,7 @@
 const { AppError, SuggestionNotFoundError } = require('@errors');
 const Suggestions = require('@models/suggestion/suggestions.model.js')
 const Curriculums = require('@models/curriculum/curriculums.model.js')
+const kebabToCamel = require('@utils/kebabToCamel')
 
 const linkCommunityMemberToSuggestion = require('./link-user')
 const assignAssociateEditorToSuggestion = require('./assign-editor')
@@ -46,9 +47,6 @@ const handleNewSuggestion = async (userId, title, text, discipline, sectionId) =
     }
 }
 
-function kebabToCamel(str) {
-    return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
-}
 
 const addToCurriculum = async (suggestionId, sectionId, discipline) => {
     try {

--- a/backend/src/utils/kebabToCamel.js
+++ b/backend/src/utils/kebabToCamel.js
@@ -1,0 +1,5 @@
+function kebabToCamel(str) {
+    return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+module.exports = kebabToCamel;


### PR DESCRIPTION
## Summary
- add `kebabToCamel` utility function in backend utils
- use the shared utility in curriculum and suggestion services

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6885c4557c8c832d9202b6a7fe06944e