### PR TITLE
Fix constants imports

### DIFF
--- a/backend/src/utils/constants/index.js
+++ b/backend/src/utils/constants/index.js
@@ -1,16 +1,6 @@
-const HTTP_STATUS = require('./http-codes')
-const { Status } = require('../../../../docs/shared/constants/status.js')
-
-
-const Roles = Object.freeze({
-    COMMUNITY_MEMBER: 'community-member',
-    REVIEWER: 'reviewer',
-    ASSOCIATE_EDITOR: 'associate-editor',
-    EDITOR_IN_CHIEF: 'editor-in-chief',
-    ACM_ED_BOARD: 'acm-ed-board'
-});
-
-
+const HTTP_STATUS = require('./http-codes');
+const { Roles } = require('@docs/constants/roles.js');
+const { Status } = require('@docs/constants/status.js');
 
 const Actions = Object.freeze({
     DESK_REJECT: 'desk-reject',
@@ -29,15 +19,7 @@ const Actions = Object.freeze({
     REJECTED_BY_EDITOR_IN_CHIEF: 'rejected-by-editor-in-chief',
     STARTED_FINAL_DISCUSSION: 'started-final-discussion',
     ACCEPTED_BY_BOARD: 'accepted-by-board',
-    DECLINED_BY_BOARD: 'declined-by-board'
-})
+    DECLINED_BY_BOARD: 'declined-by-board',
+});
 
-
-
-
-
-
-
-module.exports = { Roles, HTTP_STATUS, Status, Actions }
-
-
+module.exports = { Roles, HTTP_STATUS, Status, Actions };


### PR DESCRIPTION
## Summary
- import shared Roles and Status constants in backend

## Testing
- `node -p "require('./backend/src/utils/constants/index.js').Roles"`


------
https://chatgpt.com/codex/tasks/task_e_6885cde2582c832d96fe82a6c37da408