### PR TITLE
Fix form clearing on FinalView

### DIFF
--- a/frontend/src/components/input/Form.jsx
+++ b/frontend/src/components/input/Form.jsx
@@ -1,5 +1,7 @@
 import React, { useContext, createContext, useEffect } from 'react';
 
+const EMPTY_ARRAY = [];
+
 import styles from './inputs.module.scss';
 import { Button } from '../buttons';
 import useForm from '@hooks/useForm';
@@ -23,7 +25,7 @@ Form.propTypes = {
 export default function Form({
     children,
     defaultValues = {},
-    resetOn = [],
+    resetOn,
     className = '',
     onSubmit,
     showConfirmation,
@@ -37,8 +39,10 @@ export default function Form({
     );
 
     useEffect(() => {
-        resetForm();
-    }, resetOn);
+        if (Array.isArray(resetOn)) {
+            resetForm();
+        }
+    }, resetOn || EMPTY_ARRAY);
 
     return (
         <FormContext.Provider value={{ formData, onFormChange, resetForm }}>


### PR DESCRIPTION
## Summary
- adjust default handling for `<Form>` reset triggers
- only reset the form if dependencies supplied

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6886a2463e90832db752ad3a16f976e1