### PR TITLE
Fix CurriculumVersions search

### DIFF
--- a/backend/src/models/curriculum/versions.model.js
+++ b/backend/src/models/curriculum/versions.model.js
@@ -9,9 +9,43 @@ class CurriculumVersions {
         return this.dbRef[curriculum].data.map(v => new CurriculumVersion(v));
     }
 
+    /**
+     * Retrieves a curriculum version by ID. If the version is not present
+     * in the primary versions file, this method will check whether the ID
+     * is referenced in the table_of_contents `previous_versions` array. If
+     * so, it attempts to load the version from the default versions file
+     * bundled with the database.
+     *
+     * @param {string} curriculum - curriculum identifier (e.g. 'computer-science')
+     * @param {string} id - version identifier
+     * @returns {Promise<CurriculumVersion|null>} the version instance if found
+     */
     static async getById(curriculum, id) {
         await this.dbRef[curriculum].read();
-        const found = this.dbRef[curriculum].data.find(v => v.id === id);
+        let found = this.dbRef[curriculum].data.find(v => v.id === id);
+
+        if (!found) {
+            const tocRef = db.curriculums?.[curriculum]?.tableOfContents;
+            if (tocRef) {
+                await tocRef.read();
+                const exists = tocRef.data.some(section =>
+                    Array.isArray(section.meta?.previous_versions) &&
+                    section.meta.previous_versions.includes(id)
+                );
+
+                if (exists) {
+                    try {
+                        const defaults = require(
+                            `@database/data/curriculums/${curriculum}/default/versions.json`
+                        );
+                        found = defaults.find(v => v.id === id);
+                    } catch (err) {
+                        found = null;
+                    }
+                }
+            }
+        }
+
         return found ? new CurriculumVersion(found) : null;
     }
 


### PR DESCRIPTION
## Summary
- check table_of_contents for previous version references
- load version from default versions file if necessary

## Testing
- `npm --version`
- `npm run lint --workspaces=false` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886a496a7e4832d83ea6982be7aaaae