### PR TITLE
Fix async suggestion handling and tests

### DIFF
--- a/backend/src/features/suggestion/services/assign-editor.js
+++ b/backend/src/features/suggestion/services/assign-editor.js
@@ -58,6 +58,7 @@ const assignAssociateEditorToSuggestion = async (suggestion) => {
         }
 
         logger.info("suggestion.assign_ae.failed")
+        throw error
 
     } finally { logger.end("Assign AE to Suggestion") }
 }

--- a/backend/src/features/suggestion/services/handle-suggestion.js
+++ b/backend/src/features/suggestion/services/handle-suggestion.js
@@ -30,8 +30,9 @@ const handleNewSuggestion = async (userId, title, text, discipline, sectionId) =
         await linkCommunityMemberToSuggestion(userId, insertedSuggestion.id)
         logger.info("suggestion.post.link_user.completed")
 
-        // Set timeout so process headers are kept seperate
-        setTimeout(() => { assignAssociateEditorToSuggestion(insertedSuggestion); addToCurriculum(insertedSuggestion.id, sectionId, discipline) }, 10);
+        // Assign an Associate Editor and update the curriculum immediately
+        await assignAssociateEditorToSuggestion(insertedSuggestion);
+        await addToCurriculum(insertedSuggestion.id, sectionId, discipline);
 
         return insertedSuggestion.id
 
@@ -75,7 +76,7 @@ const addToCurriculum = async (suggestionId, sectionId, discipline) => {
         requestedCurriculum.updateToc(section)
         logger.debug("curriculum.toc.updated", { sectionId })
     } catch (error) {
-
+        throw error
     }
 }
 

--- a/testing/handle-suggestion.error.test.js
+++ b/testing/handle-suggestion.error.test.js
@@ -1,0 +1,28 @@
+require('../backend/node_modules/module-alias/register');
+
+const handleNewSuggestion = require('../backend/src/features/suggestion/services/handle-suggestion.js');
+
+async function testAssignFailure() {
+  try {
+    await handleNewSuggestion('CM-0001', 'Bad', 'bad', 'physics', 'X');
+    console.log('AE failure test: FAILED');
+  } catch (err) {
+    console.log('AE failure test:', true);
+  }
+}
+
+async function testCurriculumFailure() {
+  try {
+    await handleNewSuggestion('CM-0001', 'Bad', 'bad', 'computer-science', 'invalid-section');
+    console.log('Curriculum failure test: FAILED');
+  } catch (err) {
+    console.log('Curriculum failure test:', true);
+  }
+}
+
+if (require.main === module) {
+  (async () => {
+    await testAssignFailure();
+    await testCurriculumFailure();
+  })();
+}


### PR DESCRIPTION
## Summary
- await AE assignment and curriculum update in `handleNewSuggestion`
- propagate errors from `assignAssociateEditorToSuggestion` and `addToCurriculum`
- add failing test for AE/curriculum errors

## Testing
- `node testing/handle-suggestion.error.test.js` *(fails: Cannot find module 'nanoid')*

------
https://chatgpt.com/codex/tasks/task_e_6886c34edbc0832d825ad6846f95ba10