### PR TITLE
Handle curriculum section versioning

### DIFF
--- a/backend/src/features/curriculum/models/versions.model.js
+++ b/backend/src/features/curriculum/models/versions.model.js
@@ -1,5 +1,6 @@
 const db = require('@database/database');
 const CurriculumVersion = require('./curriculum-version.model');
+const kebabToCamel = require('@shared/utils/kebabToCamel');
 class CurriculumVersions {
     static dbRef = db.curriculums;
 
@@ -50,9 +51,13 @@ class CurriculumVersions {
 
     static async insert(curriculum, data) {
         const version = new CurriculumVersion(data).toObject();
-        await this.dbRef[curriculum].read();
-        this.dbRef[curriculum].data.push(version);
-        await this.dbRef[curriculum].write();
+        const currKey = kebabToCamel(curriculum);
+        const ref = this.dbRef?.[currKey]?.curriculumVersions;
+        if (!ref) return null;
+
+        await ref.read();
+        ref.data.push(version);
+        await ref.write();
         return version;
     }
 }

--- a/backend/src/features/suggestion/services/finalize-implementation.js
+++ b/backend/src/features/suggestion/services/finalize-implementation.js
@@ -1,6 +1,12 @@
 const { AppError, SuggestionNotFoundError } = require('@shared/errors');
 const Suggestions = require('@features/suggestion/models/suggestions.model.js');
-const { updateCurriculumSection } = require('@features/curriculum/services');
+const {
+    getCurriculumSection,
+} = require('@features/curriculum/services');
+const addCurriculumVersion = require('@features/curriculum/services/add-version');
+const { generateSectionId } = require('@shared/utils/generate-id');
+const kebabToCamel = require('@shared/utils/kebabToCamel');
+const db = require('@database/database');
 
 const logger = require('@logger').addSource({
     file: 'suggestion.service',
@@ -17,11 +23,60 @@ const finalizeImplementation = async (id, eicId, notes, message) => {
 
         logger.debug('suggestion.implement.starting');
         suggestion.finalizeImplementation(eicId, notes, message);
-        logger.debug('suggestion.implement.curriculum.updating');
-        await updateCurriculumSection(suggestion.discipline, {
-            id: suggestion.section_id,
-            content: suggestion.revised_section,
+
+        const curriculum = suggestion.discipline;
+        const camel = kebabToCamel(curriculum);
+
+        // grab current section before modifying
+        const currentSection = await getCurriculumSection(curriculum, suggestion.section_id);
+
+        if (currentSection) {
+            await addCurriculumVersion(curriculum, {
+                id: currentSection.id,
+                section_version: currentSection.meta?.section_version,
+                title: currentSection.title,
+                contributing_member: suggestion.submitter_id,
+                meta: currentSection.meta,
+                content: currentSection.content
+            });
+        }
+
+        const newMeta = { ...currentSection.meta, ...suggestion.meta };
+        const newSectionId = await generateSectionId({
+            curriculum: newMeta.curriculum,
+            year_version: newMeta.year_version,
+            page_number: newMeta.page_number,
+            slug: newMeta.slug,
+            section_version: newMeta.section_version,
         });
+
+        const tocRef = db.curriculums[camel].tableOfContents;
+        const contentRef = db.curriculums[camel].pageContent;
+        await tocRef.read();
+        await contentRef.read();
+
+        const tocIndex = tocRef.data.findIndex(s => s.id === suggestion.section_id);
+        if (tocIndex !== -1) {
+            tocRef.data[tocIndex] = {
+                ...currentSection,
+                id: newSectionId,
+                meta: newMeta
+            };
+        }
+
+        const contIndex = contentRef.data.findIndex(s => s.id === suggestion.section_id);
+        if (contIndex !== -1) {
+            contentRef.data[contIndex] = {
+                id: newSectionId,
+                content: suggestion.revised_section
+            };
+        }
+
+        await tocRef.write();
+        await contentRef.write();
+
+        suggestion.section_id = newSectionId;
+
         logger.debug('suggestion.implement.curriculum.updated');
 
         await Suggestions.update(suggestion);


### PR DESCRIPTION
## Summary
- track previous sections when implementing revisions
- generate section ID for updated content
- persist new section with updated ID and metadata
- fix curriculum version insertion helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886ff2887e8832da80c9202cd6a062f