### PR TITLE
Implement SuggestionBox form validation

### DIFF
--- a/frontend/src/components/SuggestionBox.jsx
+++ b/frontend/src/components/SuggestionBox.jsx
@@ -4,7 +4,7 @@ import useSuggestion from '@hooks/useSuggestion';
 import { UserContext } from '@context/UserProvider';
 import { useContext, useEffect } from 'react';
 
-import { Form, TextField, Dropdown, TextArea } from './input';
+import { Form, TextField, TextArea, Dropdown } from './input';
 
 export default function SuggestionBox({ sectionId }) {
     const { user } = useContext(UserContext);
@@ -88,10 +88,29 @@ const Default = ({ sectionId, submit }) => {
     return (
         <>
             <h2>Have a thought or suggestion for this section? Fill out the form below.</h2>
-            <Form resetOn={[sectionId]} onSubmit={(formData) => submit({ sectionId, discipline, ...formData })}>
-                <Dropdown keyName="type" values={options} label="Type of suggestion" required />
-                <TextField keyName="title" label="Enter a brief title explaining your suggestions" required maxLength={100} />
-                <TextArea keyName="text" label="Enter your suggestion down below" required maxLength={500} />
+            <Form
+                resetOn={[sectionId]}
+                onSubmit={(data) => submit({ sectionId, discipline, ...data })}
+            >
+                <Dropdown
+                    name="type"
+                    values={options}
+                    label="Type of suggestion"
+                    required
+                />
+                <TextField
+                    name="title"
+                    label="Enter a brief title explaining your suggestions"
+                    required
+                    maxLength={100}
+                />
+                <TextArea
+                    name="text"
+                    label="Enter your suggestion down below"
+                    required
+                    maxLength={500}
+                    className={styles['sugg-area']}
+                />
             </Form>
         </>
     );

--- a/frontend/src/components/input/Dropdown.jsx
+++ b/frontend/src/components/input/Dropdown.jsx
@@ -3,13 +3,14 @@ import styles from './inputs.module.scss'; // if you use CSS Modules
 
 export default function Dropdown({
     className = '',
+    name,
     keyName,
     val = '',
     label,
     values = [],
     ...rest
 }) {
-    const { key, value, handleChange } = useInputField({ keyName, val });
+    const { key, value, handleChange, error } = useInputField({ name, keyName, val });
 
     return (
         <>
@@ -18,7 +19,7 @@ export default function Dropdown({
                 <select
                     id={key}
                     value={value}
-                    className={className}
+                    className={`${className} ${error ? 'warning' : ''}`}
                     onChange={handleChange}
                     {...rest}
                 >
@@ -29,6 +30,7 @@ export default function Dropdown({
                     ))}
                 </select>
             </div>
+            {error && <p className="warning">{error}</p>}
         </>
     );
 }

--- a/frontend/src/components/input/Form.jsx
+++ b/frontend/src/components/input/Form.jsx
@@ -6,7 +6,7 @@ import styles from './inputs.module.scss';
 import { Button } from '../buttons';
 import useForm from '@hooks/useForm';
 import clsx from 'clsx';
-import { buildDefaultValues } from '@utils/helpers';
+import { buildDefaultValues, buildValidationRules } from '@utils/helpers';
 import useConfirmationBox from './useConfirmationBox';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
@@ -31,8 +31,12 @@ export default function Form({
     showConfirmation,
 }) {
     const builtDefaults = buildDefaultValues(children);
+    const rules = buildValidationRules(children);
     const mergedDefaults = { ...builtDefaults, ...defaultValues };
-    const { formData, onFormChange, resetForm } = useForm(mergedDefaults);
+    const { formData, onFormChange, resetForm, canSubmit, errors } = useForm(
+        mergedDefaults,
+        rules
+    );
 
     const { showing, view, open, close, submit } = useConfirmationBox(() =>
         onSubmit(formData)
@@ -45,15 +49,21 @@ export default function Form({
     }, resetOn || EMPTY_ARRAY);
 
     return (
-        <FormContext.Provider value={{ formData, onFormChange, resetForm }}>
+        <FormContext.Provider
+            value={{ formData, onFormChange, resetForm, canSubmit, errors }}
+        >
             <form className={clsx(styles.form, className)}>
                 {children}
 
                 {!showConfirmation ? (
-                    <Button onClick={() => onSubmit(formData)} text="Submit" />
+                    <Button
+                        disableOn={!canSubmit}
+                        onClick={() => onSubmit(formData)}
+                        text="Submit"
+                    />
                 ) : (
                     <>
-                        <Button onClick={open} text="Submit" />
+                        <Button disableOn={!canSubmit} onClick={open} text="Submit" />
                         <ConfirmationBox showing={showing} view={view}>
                             <Default close={close} submit={submit}>
                                 {showConfirmation.defaultInfo}

--- a/frontend/src/components/input/TextArea.jsx
+++ b/frontend/src/components/input/TextArea.jsx
@@ -2,24 +2,26 @@ import useInputField from './useInputField';
 
 export default function TextArea({
     className = '',
+    name,
     keyName,
     val = '',
     label,
     ...rest
 }) {
-    const { key, value, handleChange } = useInputField({ keyName, val });
+    const { key, value, handleChange, error } = useInputField({ name, keyName, val });
 
     return (
         <>
             {label && <label htmlFor={key}>{label}</label>}
             <textarea
                 id={key}
-                className={className}
+                className={`${className} ${error ? 'warning' : ''}`}
                 name={key}
                 value={value}
                 onChange={handleChange}
                 {...rest}
             />
+            {error && <p className="warning">{error}</p>}
         </>
     );
 }

--- a/frontend/src/components/input/TextField.jsx
+++ b/frontend/src/components/input/TextField.jsx
@@ -2,12 +2,13 @@ import useInputField from './useInputField';
 
 export default function TextField({
     className = '',
+    name,
     keyName,
     val = '',
     label,
     ...rest
 }) {
-    const { key, value, handleChange } = useInputField({ keyName, val });
+    const { key, value, handleChange, error } = useInputField({ name, keyName, val });
 
     return (
         <>
@@ -15,11 +16,12 @@ export default function TextField({
             <input
                 id={key}
                 value={value}
-                className={className}
+                className={`${className} ${error ? 'warning' : ''}`}
                 type="text"
                 onChange={handleChange}
                 {...rest}
             />
+            {error && <p className="warning">{error}</p>}
         </>
     );
 }

--- a/frontend/src/components/input/useInputField.jsx
+++ b/frontend/src/components/input/useInputField.jsx
@@ -1,11 +1,12 @@
 import { useContext } from 'react';
 import { FormContext } from './Form';
 
-export default function useInputField({ keyName, val = '' }) {
-    const { formData, onFormChange } = useContext(FormContext);
-    const value = formData[keyName] !== undefined ? formData[keyName] : val;
+export default function useInputField({ name, keyName, val = '' }) {
+    const field = name || keyName;
+    const { formData, onFormChange, errors } = useContext(FormContext);
+    const value = formData[field] !== undefined ? formData[field] : val;
 
-    const handleChange = (e) => onFormChange(keyName, e.target.value);
+    const handleChange = (e) => onFormChange(field, e.target.value);
 
-    return { key: keyName, value, handleChange };
+    return { key: field, value, handleChange, error: errors?.[field] };
 }

--- a/frontend/src/hooks/useForm.jsx
+++ b/frontend/src/hooks/useForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 /**
  * @typedef {Object} FormHook
@@ -17,16 +17,60 @@ import { useState } from 'react';
  * const { formData, onFormChange, resetForm } = useForm({ name: '', email: '' });
  */
 
-export default function useForm(defaultData = {}) {
+export default function useForm(defaultData = {}, fields = {}) {
     const [formData, setFormData] = useState(defaultData);
+    const [errors, setErrors] = useState({});
+    const [canSubmit, setCanSubmit] = useState(false);
+
+    const validateField = (field, value) => {
+        const cfg = fields[field] || {};
+
+        if (cfg.required && value.toString().trim() === '') {
+            return 'Required';
+        }
+
+        if (
+            typeof cfg.maxLength === 'number' &&
+            value.toString().length > cfg.maxLength
+        ) {
+            return `Max ${cfg.maxLength} chars`;
+        }
+
+        if (typeof cfg.validate === 'function') {
+            return cfg.validate(value) || '';
+        }
+
+        return '';
+    };
+
+    const runValidation = (data) => {
+        const newErrors = {};
+        for (const key of Object.keys(fields)) {
+            const err = validateField(key, data[key] ?? '');
+            if (err) newErrors[key] = err;
+        }
+        setErrors(newErrors);
+        setCanSubmit(Object.keys(newErrors).length === 0);
+    };
 
     const onFormChange = (field, value) => {
-        setFormData((prev) => ({ ...prev, [field]: value }));
+        setFormData((prev) => {
+            const updated = { ...prev, [field]: value };
+            runValidation(updated);
+            return updated;
+        });
     };
 
     const resetForm = () => {
         setFormData({ ...defaultData });
+        setErrors({});
+        setCanSubmit(false);
     };
 
-    return { formData, onFormChange, resetForm };
+    useEffect(() => {
+        runValidation(formData);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return { formData, errors, canSubmit, onFormChange, resetForm };
 }

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -9,11 +9,36 @@ import React from 'react';
 export const buildDefaultValues = (children) => {
     return React.Children.toArray(children).reduce((acc, child) => {
         if (React.isValidElement(child) && child.props) {
-            const { keyName, val } = child.props;
+            const { keyName, name, val } = child.props;
+            const field = name || keyName;
 
-            if (typeof keyName === 'string') {
-                acc[keyName] = val !== undefined ? val : ''; // fallback if val is undefined
+            if (typeof field === 'string') {
+                acc[field] = val !== undefined ? val : '';
             }
+        }
+        return acc;
+    }, {});
+};
+
+/**
+ * Builds validation rules from form children.
+ *
+ * @param {*} children - React children elements to process.
+ * @returns {Record<string, any>} rules per field
+ */
+export const buildValidationRules = (children) => {
+    return React.Children.toArray(children).reduce((acc, child) => {
+        if (React.isValidElement(child) && child.props) {
+            const { keyName, name, required, maxLength, validate } = child.props;
+            const field = name || keyName;
+            if (!field) return acc;
+
+            const config = {};
+            if (required) config.required = true;
+            if (typeof maxLength === 'number') config.maxLength = maxLength;
+            if (typeof validate === 'function') config.validate = validate;
+
+            acc[field] = config;
         }
         return acc;
     }, {});


### PR DESCRIPTION
## Summary
- add reusable validation helpers
- extend `useForm` with validation and error tracking
- update input `Form` to provide `canSubmit` and `errors`
- show inline validation for dropdowns, text fields, and textareas
- refactor `SuggestionBox` to leverage updated shared form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68870c05d52c832d82a1f57c27e6318a