### PR TITLE
Fix message display logic

### DIFF
--- a/frontend/src/features/community-member/Message.jsx
+++ b/frontend/src/features/community-member/Message.jsx
@@ -7,6 +7,20 @@ export const Message = ({ status, author, content, date }) => {
     const { toggle, toggleView } = useToggle();
 
     const display = toggle ? 'block' : 'none';
+
+    const extractText = (node) => {
+        if (!node) return '';
+        if (typeof node === 'string') return node;
+        if (Array.isArray(node)) return node.map(extractText).join(' ');
+        if (node.text) return node.text;
+        if (Array.isArray(node.children)) {
+            return node.children.map(extractText).join(' ');
+        }
+        return '';
+    };
+
+    const messageText = extractText(content);
+
     return (
         <div className={styles.message} onClick={toggleView}>
             <div className={styles.mssg_header}>
@@ -14,7 +28,7 @@ export const Message = ({ status, author, content, date }) => {
                 <span>{formatDate(date)}</span>
             </div>
             <div className={styles.contents} style={{ display }}>
-                <strong>{author}</strong>: {JSON.stringify(content)}
+                <strong>{author}</strong>: {messageText}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- show string messages directly or extract text from rich content objects

## Testing
- `node testing/handle-suggestion.error.test.js` *(fails: Cannot find module 'nanoid')*

------
https://chatgpt.com/codex/tasks/task_e_68872b71ebe4832d9540e0d299812d62