### PR TITLE
Update AE success modals

### DIFF
--- a/frontend/src/components/input/Form.jsx
+++ b/frontend/src/components/input/Form.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, createContext, useEffect } from 'react';
+import { XIcon } from 'lucide-react';
 
 const EMPTY_ARRAY = [];
 
@@ -22,25 +23,13 @@ Form.propTypes = {
     }),
 };
 
-export default function Form({
-    children,
-    defaultValues = {},
-    resetOn,
-    className = '',
-    onSubmit,
-    showConfirmation,
-}) {
+export default function Form({ children, defaultValues = {}, resetOn, className = '', onSubmit, showConfirmation }) {
     const builtDefaults = buildDefaultValues(children);
     const rules = buildValidationRules(children);
     const mergedDefaults = { ...builtDefaults, ...defaultValues };
-    const { formData, onFormChange, resetForm, canSubmit, errors } = useForm(
-        mergedDefaults,
-        rules
-    );
+    const { formData, onFormChange, resetForm, canSubmit, errors } = useForm(mergedDefaults, rules);
 
-    const { showing, view, open, close, submit } = useConfirmationBox(() =>
-        onSubmit(formData)
-    );
+    const { showing, view, open, close, submit } = useConfirmationBox(() => onSubmit(formData));
 
     useEffect(() => {
         if (Array.isArray(resetOn)) {
@@ -49,18 +38,12 @@ export default function Form({
     }, resetOn || EMPTY_ARRAY);
 
     return (
-        <FormContext.Provider
-            value={{ formData, onFormChange, resetForm, canSubmit, errors }}
-        >
+        <FormContext.Provider value={{ formData, onFormChange, resetForm, canSubmit, errors }}>
             <form className={clsx(styles.form, className)}>
                 {children}
 
                 {!showConfirmation ? (
-                    <Button
-                        disableOn={!canSubmit}
-                        onClick={() => onSubmit(formData)}
-                        text="Submit"
-                    />
+                    <Button disableOn={!canSubmit} onClick={() => onSubmit(formData)} text="Submit" />
                 ) : (
                     <>
                         <Button disableOn={!canSubmit} onClick={open} text="Submit" />
@@ -68,9 +51,7 @@ export default function Form({
                             <Default close={close} submit={submit}>
                                 {showConfirmation.defaultInfo}
                             </Default>
-                            <Success close={close}>
-                                {showConfirmation.successInfo}
-                            </Success>
+                            <Success close={close}>{showConfirmation.successInfo}</Success>
                             <Failure close={close} />
                         </ConfirmationBox>
                     </>
@@ -100,16 +81,10 @@ const Default = ({ children, close, submit }) => {
         <div className={styles['overlay-content']}>
             {children}
             <div className={styles['button-group']}>
-                <button
-                    className={`${styles.button} ${styles['button--cancel']}`}
-                    onClick={close}
-                >
+                <button className={`${styles.button} ${styles['button--cancel']}`} onClick={close}>
                     Cancel
                 </button>
-                <button
-                    className={`${styles.button} ${styles['button--confirm']}`}
-                    onClick={submit}
-                >
+                <button className={`${styles.button} ${styles['button--confirm']}`} onClick={submit}>
                     Confirm
                 </button>
             </div>
@@ -120,15 +95,10 @@ const Default = ({ children, close, submit }) => {
 const Success = ({ children, close }) => {
     return (
         <div className={styles['overlay-content']}>
+            <button className={styles['close-icon']} onClick={close}>
+                <XIcon size={16} />
+            </button>
             {children}
-            <div className={styles['button-group']}>
-                <button
-                    className={`${styles.button} ${styles['button--cancel']}`}
-                    onClick={close}
-                >
-                    Close
-                </button>
-            </div>
         </div>
     );
 };
@@ -138,10 +108,7 @@ const Failure = ({ close }) => {
         <div className={styles['overlay-content']}>
             Error
             <div className={styles['button-group']}>
-                <button
-                    className={`${styles.button} ${styles['button--cancel']}`}
-                    onClick={close}
-                >
+                <button className={`${styles.button} ${styles['button--cancel']}`} onClick={close}>
                     Close
                 </button>
             </div>

--- a/frontend/src/components/input/inputs.module.scss
+++ b/frontend/src/components/input/inputs.module.scss
@@ -133,8 +133,18 @@
     background: white;
     padding: 2rem 2rem;
     border-radius: 8px;
+    position: relative;
 
     width: fit-content;
+}
+
+.close-icon {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
 }
 
 .text {

--- a/frontend/src/features/associate-editor/triage-view.jsx
+++ b/frontend/src/features/associate-editor/triage-view.jsx
@@ -1,7 +1,5 @@
 import StatusIcon from '@components/Table/StatusIcon';
-import useAssociateEditor, {
-    AssociateEditor,
-} from '@features/associate-editor/useAssociateEditor';
+import useAssociateEditor, { AssociateEditor } from '@features/associate-editor/useAssociateEditor';
 import { Status } from '@utils/constants';
 import { Actions } from '@utils/constants';
 import { Form, TextArea, Dropdown } from '@components/input';
@@ -38,13 +36,10 @@ export const TriageOptionView = ({ suggestion = { id: '' }, option }) => {
                 onSubmit={variant[option]?.action}
                 showConfirmation={{
                     defaultInfo: <ConfirmBoxInfo action={option} />,
-                    successInfo: '',
+                    successInfo: <SuccessBoxInfo action={option} />,
                 }}
             >
-                <TextArea
-                    keyName="forPrivate"
-                    label={variant[option]?.topLabel}
-                />
+                <TextArea keyName="forPrivate" label={variant[option]?.topLabel} />
                 <TextArea keyName="forPublic" label="Message to submitter" />
 
                 {option === Actions.DEFER_TO_REVIEWER && (
@@ -65,8 +60,7 @@ export const TriageOptionView = ({ suggestion = { id: '' }, option }) => {
 const ConfirmBoxInfo = ({ action }) => {
     const variant = {
         [Actions.START_REVIEW]: {
-            message:
-                'Are you sure you want to begin reviewing this suggestion?',
+            message: 'Are you sure you want to begin reviewing this suggestion?',
             status: {
                 from: Status.Public.QUEUED,
                 to: Status.Public.UNDER_REVIEW,
@@ -80,8 +74,7 @@ const ConfirmBoxInfo = ({ action }) => {
             },
         },
         [Actions.DEFER_TO_REVIEWER]: {
-            message:
-                'Are you sure you want to begin reviewing this suggestion?',
+            message: 'Are you sure you want to begin reviewing this suggestion?',
             status: {
                 from: Status.Public.QUEUED,
                 to: Status.Public.UNDER_REVIEW,
@@ -91,28 +84,24 @@ const ConfirmBoxInfo = ({ action }) => {
     return (
         <>
             <p>{variant[action]?.message}</p>
-            <p style={{ fontSize: '0.95rem' }}>
-                This will change the submitter’s status from
-            </p>
+            <p style={{ fontSize: '0.95rem' }}>This will change the submitter’s status from</p>
             <div>
-                <StatusIcon status={variant[action]?.status.from} /> →{' '}
-                <StatusIcon status={variant[action]?.status.to} />
+                <StatusIcon status={variant[action]?.status.from} /> → <StatusIcon status={variant[action]?.status.to} />
             </div>
         </>
     );
 };
 
-const SuccessBoxInfo = () => {
+const SuccessBoxInfo = ({ action }) => {
+    const variant = {
+        [Actions.START_REVIEW]: 'Review process successfully started!',
+        [Actions.DESK_REJECT]: 'Suggestion was successfully desk rejected',
+        [Actions.DEFER_TO_REVIEWER]: 'Suggestion was successfully deferred to the selected reviewer',
+    };
+
     return (
         <>
-            <p>Are you sure you want to reject this suggestion?</p>
-            <p style={{ fontSize: '0.95rem' }}>
-                This will change the submitter’s status from
-            </p>
-            <div>
-                <StatusIcon status={'assigned'} /> →{' '}
-                <StatusIcon status={'rejected'} />
-            </div>
+            <p>{variant[action]}</p>
         </>
     );
 };
@@ -124,21 +113,16 @@ const Info = () => {
                 <h2>Start Review</h2>
                 <hr />
                 <p>
-                    This option is for when the Associate Editor initially
-                    reviews the suggestion and decides it should move forward in
-                    the process. When you click “Start Review,” a form will
-                    appear with two text areas:
+                    This option is for when the Associate Editor initially reviews the suggestion and decides it should move forward in the process.
+                    When you click “Start Review,” a form will appear with two text areas:
                 </p>
                 <ul>
                     <li>
-                        <strong>Initial Notes:</strong> Document any preliminary
-                        context, concerns, or details that will help yourself
-                        and others when reviewing the suggestion.
+                        <strong>Initial Notes:</strong> Document any preliminary context, concerns, or details that will help yourself and others when
+                        reviewing the suggestion.
                     </li>
                     <li>
-                        <strong>Message to Submitter:</strong> Write an
-                        acknowledgment or update that will be sent to the
-                        original submitter.
+                        <strong>Message to Submitter:</strong> Write an acknowledgment or update that will be sent to the original submitter.
                     </li>
                 </ul>
             </div>
@@ -148,19 +132,15 @@ const Info = () => {
                 <hr />
 
                 <p>
-                    Use this option if the suggestion is not suitable for
-                    further review and should be rejected without external
-                    review. A form will appear with the following fields:
+                    Use this option if the suggestion is not suitable for further review and should be rejected without external review. A form will
+                    appear with the following fields:
                 </p>
                 <ul>
                     <li>
-                        <strong>Reason:</strong> Briefly explain why the
-                        suggestion is being rejected.
+                        <strong>Reason:</strong> Briefly explain why the suggestion is being rejected.
                     </li>
                     <li>
-                        <strong>Message to Submitter:</strong> Provide a clear,
-                        respectful explanation that will be sent to the
-                        submitter.
+                        <strong>Message to Submitter:</strong> Provide a clear, respectful explanation that will be sent to the submitter.
                     </li>
                 </ul>
             </div>
@@ -169,24 +149,17 @@ const Info = () => {
                 <h2>Defer to Reviewer</h2>
                 <hr />
 
-                <p>
-                    Choose this option to assign the suggestion to a reviewer
-                    for further evaluation. A form will appear with the
-                    following fields:
-                </p>
+                <p>Choose this option to assign the suggestion to a reviewer for further evaluation. A form will appear with the following fields:</p>
                 <ul>
                     <li>
-                        <strong>Initial Notes to Reviewer:</strong> Add any
-                        context or instructions for the reviewer.
+                        <strong>Initial Notes to Reviewer:</strong> Add any context or instructions for the reviewer.
                     </li>
                     <li>
-                        <strong>Message to Submitter:</strong> Write a message
-                        that will be sent to the submitter to inform them their
-                        suggestion is under review.
+                        <strong>Message to Submitter:</strong> Write a message that will be sent to the submitter to inform them their suggestion is
+                        under review.
                     </li>
                     <li>
-                        <strong>Select Reviewer:</strong> Choose a reviewer from
-                        the dropdown list.
+                        <strong>Select Reviewer:</strong> Choose a reviewer from the dropdown list.
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- add close icon to success messages in form modals
- show success messages for all triage actions
- style overlay with close icon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68872c9b8974832d8f6a55768f7eb284