### PR TITLE
Add author names in community member updates

### DIFF
--- a/backend/src/features/suggestion/services/get-one.js
+++ b/backend/src/features/suggestion/services/get-one.js
@@ -3,6 +3,7 @@ const { Roles } = require('@docs/constants/roles.js')
 const Suggestions = require('@features/suggestion/models/suggestions.model.js')
 const Curriculums = require('@features/curriculum/models/curriculums.model.js')
 const kebabToCamel = require('@shared/utils/kebabToCamel')
+const getUserNameById = require('@shared/utils/getUserNameById')
 const logger = require('@logger').addSource({
     file: 'auth.service',
     method: "assignAssociateEditorToSuggestion",
@@ -28,6 +29,13 @@ const getSuggestionById = async (suggestionId, role = null) => {
         if (role) {
             if (role === Roles.COMMUNITY_MEMBER) {
                 retS = requestedSuggestion.toCommunityMember()
+                if (Array.isArray(retS.publicUpdates)) {
+                    for (const update of retS.publicUpdates) {
+                        if (typeof update.author === 'string' && update.author !== 'LiveC') {
+                            update.author = await getUserNameById(update.author)
+                        }
+                    }
+                }
             } else if (role === Roles.ASSOCIATE_EDITOR) {
                 retS = requestedSuggestion.toAssociateEditor()
             } else if (role === Roles.EDITOR_IN_CHIEF) {

--- a/backend/src/features/users/services/users/community-member/get-suggestions.js
+++ b/backend/src/features/users/services/users/community-member/get-suggestions.js
@@ -1,5 +1,6 @@
 const { AppError } = require('@shared/errors');
 const Suggestions = require('@features/suggestion/models/suggestions.model.js')
+const getUserNameById = require('@shared/utils/getUserNameById')
 
 const logger = require('@logger').addSource({
     file: 'community-member.service',
@@ -14,6 +15,16 @@ const getAllCommunityMemberSuggestions = async (userId) => {
 
         logger.debug(`cm.suggestions.get.db.searching`)
         const suggestions = await Suggestions.getByCommunityMemberId(userId)
+
+        for (const suggestion of suggestions) {
+            if (Array.isArray(suggestion.publicUpdates)) {
+                for (const update of suggestion.publicUpdates) {
+                    if (typeof update.author === 'string' && update.author !== 'LiveC') {
+                        update.author = await getUserNameById(update.author)
+                    }
+                }
+            }
+        }
 
         return suggestions
 

--- a/backend/src/shared/utils/getUserNameById.js
+++ b/backend/src/shared/utils/getUserNameById.js
@@ -1,0 +1,21 @@
+const db = require('@database/database');
+
+const roleMap = {
+    CM: 'communityMembers',
+    AE: 'associateEditors',
+    R: 'reviewers',
+    EIC: 'chiefEditors'
+};
+
+async function getUserNameById(id) {
+    const prefix = id.split('-')[0];
+    const roleKey = roleMap[prefix];
+    if (!roleKey) return id;
+    const dbRef = db.users[roleKey];
+    if (!dbRef) return id;
+    await dbRef.read();
+    const found = dbRef.data.find(u => u.id === id);
+    return found ? found.name : id;
+}
+
+module.exports = getUserNameById;


### PR DESCRIPTION
## Summary
- map IDs to user names when returning community member suggestions
- perform the same mapping when fetching a single suggestion
- add utility `getUserNameById` to resolve user IDs

## Testing
- `node -r ./backend/node_modules/module-alias/register -e "const getUserNameById=require('./backend/src/shared/utils/getUserNameById'); getUserNameById('CM-0001').then(n=>console.log('name',n))"`

------
https://chatgpt.com/codex/tasks/task_e_68872f3805b4832d96e75786194873fd