### PR TITLE
Display author details on document cards

### DIFF
--- a/backend/src/features/suggestion/services/get-one.js
+++ b/backend/src/features/suggestion/services/get-one.js
@@ -4,6 +4,7 @@ const Suggestions = require('@features/suggestion/models/suggestions.model.js')
 const Curriculums = require('@features/curriculum/models/curriculums.model.js')
 const kebabToCamel = require('@shared/utils/kebabToCamel')
 const getUserNameById = require('@shared/utils/getUserNameById')
+const getUserInfoById = require('@shared/utils/getUserInfoById')
 const logger = require('@logger').addSource({
     file: 'auth.service',
     method: "assignAssociateEditorToSuggestion",
@@ -42,6 +43,16 @@ const getSuggestionById = async (suggestionId, role = null) => {
                 retS = requestedSuggestion.toEditorInChief()
             } else if (role === Roles.REVIEWER) {
                 retS = requestedSuggestion.toReviewer()
+            }
+        }
+
+        if (Array.isArray(retS.documentation)) {
+            for (const doc of retS.documentation) {
+                if (typeof doc.author === 'string' && doc.author !== 'LiveC') {
+                    const { name, role: authorRole } = await getUserInfoById(doc.author)
+                    doc.authorName = name
+                    doc.authorRole = authorRole
+                }
             }
         }
 

--- a/backend/src/shared/utils/getUserInfoById.js
+++ b/backend/src/shared/utils/getUserInfoById.js
@@ -1,0 +1,21 @@
+const db = require('@database/database');
+
+const roleMap = {
+    CM: 'communityMembers',
+    AE: 'associateEditors',
+    R: 'reviewers',
+    EIC: 'chiefEditors',
+};
+
+async function getUserInfoById(id) {
+    const prefix = id.split('-')[0];
+    const roleKey = roleMap[prefix];
+    if (!roleKey) return { name: id, role: 'unknown' };
+    const dbRef = db.users[roleKey];
+    if (!dbRef) return { name: id, role: 'unknown' };
+    await dbRef.read();
+    const found = dbRef.data.find((u) => u.id === id);
+    return found ? { name: found.name, role: found.role } : { name: id, role: 'unknown' };
+}
+
+module.exports = getUserInfoById;

--- a/frontend/src/features/document/Card.jsx
+++ b/frontend/src/features/document/Card.jsx
@@ -4,7 +4,8 @@ import icon from '/profile.svg';
 import { FlexRow, FlexColumn } from '@components/layouts/flex';
 
 export default function Card({ doc, setDocText }) {
-    const { author, date, content } = doc;
+    const { authorName, authorRole, date, content } = doc;
+    const displayName = authorName || doc.author;
 
     return (
         <FlexRow
@@ -14,7 +15,8 @@ export default function Card({ doc, setDocText }) {
         >
             <img src={icon} width={50} height={50} />
             <FlexColumn>
-                <p>{author}</p>
+                <p>{displayName}</p>
+                {authorRole && <p><i>{authorRole}</i></p>}
                 <p>Added on {formatDate(date)}</p>
             </FlexColumn>
         </FlexRow>


### PR DESCRIPTION
## Summary
- add helper to lookup user info by id
- enrich suggestion `documentation` with author name & role
- show author name and italicized role in document cards

## Testing
- `node testing/handle-suggestion.error.test.js` *(fails: Cannot find module 'nanoid')*

------
https://chatgpt.com/codex/tasks/task_e_688731bd6630832d977760aa22466663