### PR TITLE
Switch AE reviewer list to card layout

### DIFF
--- a/frontend/src/features/associate-editor/ReviewerCard.jsx
+++ b/frontend/src/features/associate-editor/ReviewerCard.jsx
@@ -1,0 +1,32 @@
+import { FlexRow, FlexColumn } from '@components/layouts/flex';
+import { Button } from '@components/buttons';
+import styles from './ReviewerCard.module.scss';
+import icon from '/profile.svg';
+import clsx from 'clsx';
+
+export default function ReviewerCard({ reviewer, status = '', disabled = false, onInvite }) {
+    const handleClick = () => {
+        if (!disabled && onInvite) onInvite();
+    };
+
+    return (
+        <FlexRow
+            className={clsx(styles.card, disabled && styles.disabled)}
+            align="center"
+        >
+            <img src={icon} width={40} height={40} />
+            <FlexColumn className={styles.info}>
+                <p>{reviewer.name}</p>
+                {status && <span className={styles.status}>{status}</span>}
+            </FlexColumn>
+            {!disabled && (
+                <Button
+                    variant="gray"
+                    size="fit"
+                    text="Invite"
+                    onClick={handleClick}
+                />
+            )}
+        </FlexRow>
+    );
+}

--- a/frontend/src/features/associate-editor/ReviewerCard.module.scss
+++ b/frontend/src/features/associate-editor/ReviewerCard.module.scss
@@ -1,0 +1,27 @@
+@use '@styles' as *;
+
+.card {
+    cursor: pointer;
+    border-radius: 8px;
+    background-color: $stone-200;
+    gap: 1rem;
+    padding: 0.5rem;
+
+    &:hover {
+        background-color: $stone-300;
+    }
+}
+
+.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.card + .card {
+    margin-top: 1rem;
+}
+
+.status {
+    font-size: 0.85rem;
+    color: $gray-600;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -71,6 +71,10 @@
     overflow-y: auto;
 }
 
+.reviewer-cards {
+    overflow-y: auto;
+}
+
 .doc_heading {
     margin-bottom: 1rem;
 }

--- a/frontend/src/pages/dashboard/suggestion/FullView.jsx
+++ b/frontend/src/pages/dashboard/suggestion/FullView.jsx
@@ -12,7 +12,8 @@ import Modal, { DefaultView, ConfirmationView } from '@components/popups/Modal';
 import Card from '@features/document/Card';
 import Documentation from '@features/document/Documentation';
 import Page from '@features/details/Page';
-import { Form, CheckboxGroup, RadioGroup, RadioAsCheckbox, TextArea } from '@components/input';
+import { Form, RadioAsCheckbox, TextArea } from '@components/input';
+import ReviewerCard from '@features/associate-editor/ReviewerCard';
 // ─── Feature Components ──────────────────────────────────────────────────
 import Suggestion from '@features/suggestion/Suggestion';
 import ActionButtons from '@features/editor-in-chief/ActionButtons';
@@ -176,25 +177,44 @@ const SuggestionContent = ({ suggestion, role }) => {
     );
 };
 
+
 const Revs = ({ suggestion }) => {
     const { reviewers, assign } = useAssociateEditor();
 
-    const assigned = Array.isArray(suggestion.assignedReviewers) ? suggestion.assignedReviewers.map((r) => r.id) : [];
+    if (suggestion.system.status === Status.System.AWAITING_EIC_INPUT) return null;
 
-    const options = reviewers
-        .filter((item) => !assigned.includes(item.id))
-        .map((item) => ({
-            label: item.name,
-            value: item.id,
-        }));
+    const assignedMap = {};
+    (suggestion.assignedReviewers || []).forEach((r) => {
+        assignedMap[r.id] = r.recommendation;
+    });
 
-    if (suggestion.system.status === Status.System.AWAITING_EIC_INPUT) return;
+    const handleInvite = (id) => assign(suggestion.id, { reviewers: [id] });
+
     return (
         <>
             <h2>Assign Reviewers</h2>
-            <Form onSubmit={(formData) => assign(suggestion.id, formData)}>
-                <CheckboxGroup options={options} keyName="reviewers" />
-            </Form>
+            <div className="reviewer-cards">
+                {reviewers.map((rev) => {
+                    const rec = assignedMap[rev.id];
+                    let status = '';
+                    let disabled = false;
+
+                    if (rec) {
+                        status = rec === 'pending' ? 'Reviewing' : 'Reviewed';
+                        disabled = true;
+                    }
+
+                    return (
+                        <ReviewerCard
+                            key={rev.id}
+                            reviewer={rev}
+                            status={status}
+                            disabled={disabled}
+                            onInvite={() => handleInvite(rev.id)}
+                        />
+                    );
+                })}
+            </div>
         </>
     );
 };


### PR DESCRIPTION
## Summary
- add ReviewerCard component for selecting reviewers
- show reviewer cards in AE suggestion view instead of checkboxes
- disable cards for reviewers who are already reviewing or finished
- expose simple style for reviewer card list

## Testing
- `npm run lint` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688741334284832db3cf77b41c2de4c3