### PR TITLE
Add mock updates, history, and docs to demo suggestions

### DIFF
--- a/backend/src/database/data/suggestions/default/suggestions.json
+++ b/backend/src/database/data/suggestions/default/suggestions.json
@@ -1,3 +1,589 @@
 [
-  
+  {
+    "id": "SCOSC-DEMO1",
+    "title": "Clarify aims in Executive Summary",
+    "text": "Add a brief paragraph summarizing key aims of CS2023",
+    "suggestion": "Add a brief paragraph summarizing key aims of CS2023",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0001",
+    "section_id": "d3b1d0eaf0e4",
+    "time_created": "2025-01-01T00:00:00.000Z",
+    "status": {
+      "for_member": "submitted",
+      "system": "initial-submission"
+    },
+    "discipline": "computer-science",
+    "public_updates": [
+      {
+        "refId": "PU1-1",
+        "status": "submitted",
+        "date": "2025-01-01T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "submitted-by-member",
+        "refId": "DOC1-1",
+        "author": "CM-0001",
+        "date": "2025-01-01T00:00:00.000Z",
+        "content": "Initial submission"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0001",
+        "date": "2025-01-01T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO2",
+    "title": "Update overview examples",
+    "text": "Refresh examples in the overview section to include recent technologies",
+    "suggestion": "Refresh examples in the overview section to include recent technologies",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0002",
+    "section_id": "f95611b734d5",
+    "time_created": "2025-01-02T00:00:00.000Z",
+    "status": {
+      "for_member": "queued",
+      "for_associate_editor": "new",
+      "system": "preliminary-review"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0001",
+    "public_updates": [
+      {
+        "refId": "PU2-1",
+        "status": "submitted",
+        "date": "2025-01-02T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU2-2",
+        "status": "queued",
+        "date": "2025-01-02T00:00:00.000Z",
+        "message": "An associate editor has been assigned.",
+        "author": "LiveC"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "assigned-associate-editor",
+        "refId": "DOC2-1",
+        "author": "LiveC",
+        "date": "2025-01-02T00:00:00.000Z",
+        "content": "AE assigned"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0002",
+        "date": "2025-01-02T00:00:00.000Z"
+      },
+      {
+        "action": "assigned-associate-editor",
+        "performed_by": "LiveC",
+        "date": "2025-01-02T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO3",
+    "title": "Expand introduction to highlight AI",
+    "text": "Include a short subsection on AI advancements in the introduction",
+    "suggestion": "Include a short subsection on AI advancements in the introduction",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0003",
+    "section_id": "b47742cdb750",
+    "time_created": "2025-01-03T00:00:00.000Z",
+    "status": {
+      "for_member": "under-review",
+      "for_associate_editor": "reviewing",
+      "system": "editorial-review"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0002",
+    "public_updates": [
+      {
+        "refId": "PU3-1",
+        "status": "submitted",
+        "date": "2025-01-03T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU3-2",
+        "status": "queued",
+        "date": "2025-01-03T00:00:00.000Z",
+        "message": "An associate editor has been assigned.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU3-3",
+        "status": "under-review",
+        "date": "2025-01-03T00:00:00.000Z",
+        "message": "The associate editor is reviewing your suggestion.",
+        "author": "AE-0002"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "start-review",
+        "refId": "DOC3-1",
+        "author": "AE-0002",
+        "date": "2025-01-03T00:00:00.000Z",
+        "content": "AE started review"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0003",
+        "date": "2025-01-03T00:00:00.000Z"
+      },
+      {
+        "action": "assigned-associate-editor",
+        "performed_by": "LiveC",
+        "date": "2025-01-03T00:00:00.000Z"
+      },
+      {
+        "action": "start-review",
+        "performed_by": "AE-0002",
+        "date": "2025-01-03T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO4",
+    "title": "Add more historical context",
+    "text": "Provide additional detail on early computing milestones",
+    "suggestion": "Provide additional detail on early computing milestones",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0004",
+    "section_id": "afb872230af3",
+    "time_created": "2025-01-04T00:00:00.000Z",
+    "status": {
+      "for_member": "under-consideration",
+      "for_associate_editor": "approved",
+      "for_editor_in_chief": "ready-for-discussion",
+      "system": "awaiting-board-discussion"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0003",
+    "assigned_editor_in_chief": "EIC-0001",
+    "public_updates": [
+      {
+        "refId": "PU4-1",
+        "status": "submitted",
+        "date": "2025-01-04T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU4-2",
+        "status": "queued",
+        "date": "2025-01-04T00:00:00.000Z",
+        "message": "An associate editor has been assigned.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU4-3",
+        "status": "under-review",
+        "date": "2025-01-04T00:00:00.000Z",
+        "message": "The associate editor is reviewing your suggestion.",
+        "author": "AE-0003"
+      },
+      {
+        "refId": "PU4-4",
+        "status": "under-consideration",
+        "date": "2025-01-04T00:00:00.000Z",
+        "message": "The Editor in Chief is considering your suggestion.",
+        "author": "EIC-0001"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "approved-by-editor-in-chief",
+        "refId": "DOC4-1",
+        "author": "EIC-0001",
+        "date": "2025-01-04T00:00:00.000Z",
+        "content": "Approved for board discussion"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0004",
+        "date": "2025-01-04T00:00:00.000Z"
+      },
+      {
+        "action": "assigned-associate-editor",
+        "performed_by": "LiveC",
+        "date": "2025-01-04T00:00:00.000Z"
+      },
+      {
+        "action": "start-review",
+        "performed_by": "AE-0003",
+        "date": "2025-01-04T00:00:00.000Z"
+      },
+      {
+        "action": "finalized-by-associate-editor",
+        "performed_by": "AE-0003",
+        "date": "2025-01-04T00:00:00.000Z"
+      },
+      {
+        "action": "approved-by-editor-in-chief",
+        "performed_by": "EIC-0001",
+        "date": "2025-01-04T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO5",
+    "title": "Revise vision statement to emphasize ethics",
+    "text": "Strengthen the vision statement with an explicit focus on ethical practice",
+    "suggestion": "Strengthen the vision statement with an explicit focus on ethical practice",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0005",
+    "section_id": "c2824056be4f",
+    "time_created": "2025-01-05T00:00:00.000Z",
+    "status": {
+      "for_member": "under-discussion",
+      "for_associate_editor": "join-discussion",
+      "for_editor_in_chief": "started-discussion",
+      "system": "in-board-discussion"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0004",
+    "assigned_editor_in_chief": "EIC-0002",
+    "public_updates": [
+      {
+        "refId": "PU5-1",
+        "status": "submitted",
+        "date": "2025-01-05T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU5-2",
+        "status": "queued",
+        "date": "2025-01-05T00:00:00.000Z",
+        "message": "An associate editor has been assigned.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU5-3",
+        "status": "under-review",
+        "date": "2025-01-05T00:00:00.000Z",
+        "message": "The associate editor is reviewing your suggestion.",
+        "author": "AE-0004"
+      },
+      {
+        "refId": "PU5-4",
+        "status": "under-consideration",
+        "date": "2025-01-05T00:00:00.000Z",
+        "message": "The Editor in Chief is considering your suggestion.",
+        "author": "EIC-0002"
+      },
+      {
+        "refId": "PU5-5",
+        "status": "under-discussion",
+        "date": "2025-01-05T00:00:00.000Z",
+        "message": "The board is discussing your suggestion.",
+        "author": "EIC-0002"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "started-final-discussion",
+        "refId": "DOC5-1",
+        "author": "EIC-0002",
+        "date": "2025-01-05T00:00:00.000Z",
+        "content": "Board discussion opened"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0005",
+        "date": "2025-01-05T00:00:00.000Z"
+      },
+      {
+        "action": "assigned-associate-editor",
+        "performed_by": "LiveC",
+        "date": "2025-01-05T00:00:00.000Z"
+      },
+      {
+        "action": "start-review",
+        "performed_by": "AE-0004",
+        "date": "2025-01-05T00:00:00.000Z"
+      },
+      {
+        "action": "finalized-by-associate-editor",
+        "performed_by": "AE-0004",
+        "date": "2025-01-05T00:00:00.000Z"
+      },
+      {
+        "action": "started-final-discussion",
+        "performed_by": "EIC-0002",
+        "date": "2025-01-05T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO6",
+    "title": "Include key references for CS2023",
+    "text": "Add citations for foundational CS2023 research articles",
+    "suggestion": "Add citations for foundational CS2023 research articles",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0006",
+    "section_id": "df7bdf438dcb",
+    "time_created": "2025-01-06T00:00:00.000Z",
+    "status": {
+      "for_member": "accepted",
+      "for_associate_editor": "completed",
+      "for_editor_in_chief": "accepted-unanimously",
+      "system": "ready-for-implementation"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0005",
+    "assigned_editor_in_chief": "EIC-0003",
+    "public_updates": [
+      {
+        "refId": "PU6-1",
+        "status": "submitted",
+        "date": "2025-01-06T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU6-2",
+        "status": "queued",
+        "date": "2025-01-06T00:00:00.000Z",
+        "message": "An associate editor has been assigned.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU6-3",
+        "status": "under-review",
+        "date": "2025-01-06T00:00:00.000Z",
+        "message": "The associate editor is reviewing your suggestion.",
+        "author": "AE-0005"
+      },
+      {
+        "refId": "PU6-4",
+        "status": "under-consideration",
+        "date": "2025-01-06T00:00:00.000Z",
+        "message": "The Editor in Chief is considering your suggestion.",
+        "author": "EIC-0003"
+      },
+      {
+        "refId": "PU6-5",
+        "status": "accepted",
+        "date": "2025-01-06T00:00:00.000Z",
+        "message": "Your suggestion has been accepted and will be implemented.",
+        "author": "EIC-0003"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "approved-by-editor-in-chief",
+        "refId": "DOC6-1",
+        "author": "EIC-0003",
+        "date": "2025-01-06T00:00:00.000Z",
+        "content": "Accepted for implementation"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0006",
+        "date": "2025-01-06T00:00:00.000Z"
+      },
+      {
+        "action": "assigned-associate-editor",
+        "performed_by": "LiveC",
+        "date": "2025-01-06T00:00:00.000Z"
+      },
+      {
+        "action": "start-review",
+        "performed_by": "AE-0005",
+        "date": "2025-01-06T00:00:00.000Z"
+      },
+      {
+        "action": "finalized-by-associate-editor",
+        "performed_by": "AE-0005",
+        "date": "2025-01-06T00:00:00.000Z"
+      },
+      {
+        "action": "approved-by-editor-in-chief",
+        "performed_by": "EIC-0003",
+        "date": "2025-01-06T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO7",
+    "title": "Add definitions of key terms",
+    "text": "Create a glossary of important terminology",
+    "suggestion": "Create a glossary of important terminology",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0007",
+    "section_id": "8238a7d96075",
+    "time_created": "2025-01-07T00:00:00.000Z",
+    "status": {
+      "for_member": "implemented",
+      "for_associate_editor": "completed",
+      "for_editor_in_chief": "published",
+      "system": "closed"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0006",
+    "assigned_editor_in_chief": "EIC-0004",
+    "public_updates": [
+      {
+        "refId": "PU7-1",
+        "status": "submitted",
+        "date": "2025-01-07T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU7-2",
+        "status": "queued",
+        "date": "2025-01-07T00:00:00.000Z",
+        "message": "An associate editor has been assigned.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU7-3",
+        "status": "under-review",
+        "date": "2025-01-07T00:00:00.000Z",
+        "message": "The associate editor is reviewing your suggestion.",
+        "author": "AE-0006"
+      },
+      {
+        "refId": "PU7-4",
+        "status": "under-consideration",
+        "date": "2025-01-07T00:00:00.000Z",
+        "message": "The Editor in Chief is considering your suggestion.",
+        "author": "EIC-0004"
+      },
+      {
+        "refId": "PU7-5",
+        "status": "accepted",
+        "date": "2025-01-07T00:00:00.000Z",
+        "message": "Your suggestion has been accepted.",
+        "author": "EIC-0004"
+      },
+      {
+        "refId": "PU7-6",
+        "status": "implemented",
+        "date": "2025-01-07T00:00:00.000Z",
+        "message": "The change has been implemented and published.",
+        "author": "EIC-0004"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "published-by-eic",
+        "refId": "DOC7-1",
+        "author": "EIC-0004",
+        "date": "2025-01-07T00:00:00.000Z",
+        "content": "Published"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0007",
+        "date": "2025-01-07T00:00:00.000Z"
+      },
+      {
+        "action": "assigned-associate-editor",
+        "performed_by": "LiveC",
+        "date": "2025-01-07T00:00:00.000Z"
+      },
+      {
+        "action": "start-review",
+        "performed_by": "AE-0006",
+        "date": "2025-01-07T00:00:00.000Z"
+      },
+      {
+        "action": "finalized-by-associate-editor",
+        "performed_by": "AE-0006",
+        "date": "2025-01-07T00:00:00.000Z"
+      },
+      {
+        "action": "approved-by-editor-in-chief",
+        "performed_by": "EIC-0004",
+        "date": "2025-01-07T00:00:00.000Z"
+      },
+      {
+        "action": "published-by-eic",
+        "performed_by": "EIC-0004",
+        "date": "2025-01-07T00:00:00.000Z"
+      }
+    ]
+  },
+  {
+    "id": "SCOSC-DEMO8",
+    "title": "Remove outdated terminology",
+    "text": "Replace obsolete jargon with modern terminology",
+    "suggestion": "Replace obsolete jargon with modern terminology",
+    "type": "update-existing-knowledge-area",
+    "submitter_id": "CM-0008",
+    "section_id": "e4589cbb1122",
+    "time_created": "2025-01-08T00:00:00.000Z",
+    "status": {
+      "for_member": "rejected",
+      "for_associate_editor": "declined",
+      "system": "closed-rejected"
+    },
+    "discipline": "computer-science",
+    "assigned_associate_editor": "AE-0007",
+    "public_updates": [
+      {
+        "refId": "PU8-1",
+        "status": "submitted",
+        "date": "2025-01-08T00:00:00.000Z",
+        "message": "Your suggestion has been submitted.",
+        "author": "LiveC"
+      },
+      {
+        "refId": "PU8-2",
+        "status": "rejected",
+        "date": "2025-01-08T00:00:00.000Z",
+        "message": "Your suggestion was rejected by the associate editor.",
+        "author": "AE-0007"
+      }
+    ],
+    "documentation": [
+      {
+        "action": "desk-reject",
+        "refId": "DOC8-1",
+        "author": "AE-0007",
+        "date": "2025-01-08T00:00:00.000Z",
+        "content": "Not aligned with current goals"
+      }
+    ],
+    "history": [
+      {
+        "action": "submitted-by-member",
+        "performed_by": "CM-0008",
+        "date": "2025-01-08T00:00:00.000Z"
+      },
+      {
+        "action": "desk-reject",
+        "performed_by": "AE-0007",
+        "date": "2025-01-08T00:00:00.000Z"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
## Summary
- expand default `suggestions.json` with example `public_updates`, `history`, and `documentation` for each stage

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('backend/src/database/data/suggestions/default/suggestions.json'));console.log('JSON valid');"`

------
https://chatgpt.com/codex/tasks/task_e_68874632570c832d8b0cba3ef96129c5