### PR TITLE
Improve editor action confirmation flows

### DIFF
--- a/frontend/src/components/input/Form.jsx
+++ b/frontend/src/components/input/Form.jsx
@@ -106,7 +106,8 @@ const Success = ({ children, close }) => {
 const Failure = ({ close }) => {
     return (
         <div className={styles['overlay-content']}>
-            Error
+            <p>An error occurred while processing your request.</p>
+            <p>Please try again later.</p>
             <div className={styles['button-group']}>
                 <button className={`${styles.button} ${styles['button--cancel']}`} onClick={close}>
                     Close

--- a/frontend/src/components/popups/ModalContext.jsx
+++ b/frontend/src/components/popups/ModalContext.jsx
@@ -20,6 +20,7 @@ export default function ModalProvider({ children, onSubmit }) {
             navigate(0);
         }
         setShowing(false);
+        setView('default');
     };
 
     const values = {

--- a/frontend/src/features/associate-editor/useAssociateEditor.jsx
+++ b/frontend/src/features/associate-editor/useAssociateEditor.jsx
@@ -158,13 +158,15 @@ export default function useAssociateEditor() {
         const updatedSection = JSON.parse(localStorage.getItem(suggestionId));
         if (!updatedSection) throw new Error('No updated section available');
         try {
-            await postAssociateEditorFinalization(
+            const success = await postAssociateEditorFinalization(
                 associateEditorId,
                 suggestionId,
                 updatedSection
             );
+            return success;
         } catch (error) {
             // ignore
+            return false;
         }
     };
 

--- a/frontend/src/features/editor-in-chief/useEditorInChief.jsx
+++ b/frontend/src/features/editor-in-chief/useEditorInChief.jsx
@@ -29,14 +29,15 @@ export default function useEditorInChief() {
     const approveSuggestion = async (suggestionId, formData) => {
         try {
             const { forPrivate, forPublic } = formData;
-            await postEditorInChiefApproval(
+            const success = await postEditorInChiefApproval(
                 suggestionId,
                 editorInChiefId,
                 forPrivate,
                 forPublic
             );
+            return success;
         } catch (error) {
-            // ignore
+            return false;
         }
     };
 
@@ -53,9 +54,14 @@ export default function useEditorInChief() {
     const sendChangeRequest = async (suggestionId, formData) => {
         try {
             const { forPrivate } = formData;
-            await postChangeRequest(suggestionId, editorInChiefId, forPrivate);
+            const success = await postChangeRequest(
+                suggestionId,
+                editorInChiefId,
+                forPrivate
+            );
+            return success;
         } catch (error) {
-            // ignore
+            return false;
         }
     };
 
@@ -86,9 +92,11 @@ export default function useEditorInChief() {
 
     const startDiscussion = async (suggestionId) => {
         try {
-            await postDiscussion(suggestionId, editorInChiefId);
+            const success = await postDiscussion(suggestionId, editorInChiefId);
+            return success;
         } catch (error) {
             // ignore
+            return false;
         }
     };
 

--- a/frontend/src/features/reviewer/useReviewer.jsx
+++ b/frontend/src/features/reviewer/useReviewer.jsx
@@ -19,8 +19,11 @@ export default function useReviewer() {
     const reviewerId = user.id;
 
     const recommend = async (id, { decision, notes }) => {
-        await postRecommednation(id, reviewerId, { decision, notes });
-        navigate(0);
+        const success = await postRecommednation(id, reviewerId, {
+            decision,
+            notes,
+        });
+        return success;
     };
 
     const decide = async (id, { decision, notes }) => {

--- a/frontend/src/pages/dashboard/suggestion/FullView.jsx
+++ b/frontend/src/pages/dashboard/suggestion/FullView.jsx
@@ -150,6 +150,7 @@ const SuggestionContent = ({ suggestion, role }) => {
                         variant="confirm"
                         text="Start Discussion"
                         onClick={() => startDiscussion(suggestion.id)}
+                        modal={<StartDiscussionModal />}
                     />
                 )}
                 {role === Roles.REVIEWER &&
@@ -158,7 +159,7 @@ const SuggestionContent = ({ suggestion, role }) => {
                         <Form
                             showConfirmation={{
                                 defaultInfo: <RecModal />,
-                                successInfo: <></>,
+                                successInfo: <p>Recommendation submitted!</p>,
                             }}
                             onSubmit={(formData) => recommend(suggestion.id, formData)}
                         >
@@ -260,14 +261,19 @@ const FinalizeModal = () => {
     return (
         <Modal>
             <DefaultView message="Are you sure you want to finalize this suggestion?"></DefaultView>
-            <ConfirmationView message={'Success'} />
+            <ConfirmationView message={'Suggestion was successfully finalized!'} />
         </Modal>
     );
 };
 const RecModal = () => {
     return (
-        <>
-            <p>Are you sure do that...</p>
-        </>
+        <>Are you sure you want to submit this recommendation?</>
     );
 };
+
+const StartDiscussionModal = () => (
+    <Modal>
+        <DefaultView message="Start board discussion for this suggestion?" />
+        <ConfirmationView message={'Discussion successfully started!'} />
+    </Modal>
+);

--- a/frontend/src/utils/api-handlers/suggestions/post-approval.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-approval.js
@@ -16,7 +16,14 @@ import { apiLog as log } from '../apiLogger';
 export const postEditorInChiefApproval = async (id, eicId, notes, message) => {
     try {
         log.debug('EIC approval', id, eicId, notes, message);
-        await API.post(`/suggestion/${id}/approve`, { eicId, notes, message });
+        const response = await API.post(`/suggestion/${id}/approve`, {
+            eicId,
+            notes,
+            message,
+        });
+        const { success, message: msg } = response.data;
+        log.success(msg);
+        return success;
     } catch (error) {
         log.error(error);
     }

--- a/frontend/src/utils/api-handlers/suggestions/post-change.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-change.js
@@ -15,7 +15,13 @@ import { apiLog as log } from '../apiLogger';
 export const postChangeRequest = async (id, eic, change) => {
     try {
         log.debug('Change request', id, eic, change);
-        await API.post(`/suggestion/${id}/change-request`, { eic, change });
+        const response = await API.post(`/suggestion/${id}/change-request`, {
+            eic,
+            change,
+        });
+        const { success, message } = response.data;
+        log.success(message);
+        return success;
     } catch (error) {
         log.error(error);
     }

--- a/frontend/src/utils/api-handlers/suggestions/post-discussion.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-discussion.js
@@ -13,7 +13,12 @@ import { apiLog as log } from '../apiLogger';
 export const postDiscussion = async (id, eicId,) => {
     try {
         log.debug('Start discussion', id, eicId);
-        await API.post(`/suggestion/${id}/start-discussion`, { eicId });
+        const response = await API.post(`/suggestion/${id}/start-discussion`, {
+            eicId,
+        });
+        const { success, message } = response.data;
+        log.success(message);
+        return success;
     } catch (error) {
         log.error(error);
     }

--- a/frontend/src/utils/api-handlers/suggestions/post-finalize.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-finalize.js
@@ -19,10 +19,13 @@ export const postAssociateEditorFinalization = async (
     updatedSection
 ) => {
     try {
-        await API.post(`/suggestion/${suggestionId}/finalize`, {
+        const response = await API.post(`/suggestion/${suggestionId}/finalize`, {
             associateEditor,
             updatedSection,
         });
+        const { success, message } = response.data;
+        log.success(message);
+        return success;
     } catch (error) {
         log.error(error);
     }

--- a/frontend/src/utils/api-handlers/suggestions/post-recommendation.js
+++ b/frontend/src/utils/api-handlers/suggestions/post-recommendation.js
@@ -7,11 +7,17 @@ export const postRecommednation = async (
     { decision, notes }
 ) => {
     try {
-        await API.post(`/suggestion/${suggestionId}/post-recommendation`, {
-            reviewerId,
-            decision,
-            notes,
-        });
+        const response = await API.post(
+            `/suggestion/${suggestionId}/post-recommendation`,
+            {
+                reviewerId,
+                decision,
+                notes,
+            }
+        );
+        const { success, message } = response.data;
+        log.success(message);
+        return success;
     } catch (error) {
         log.error(error);
     }


### PR DESCRIPTION
## Summary
- propagate success values from editor API handlers
- reload after recommending or finalizing a suggestion
- show success state for chief approvals and change requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68874c024f5c832d95e9d4905249924b