### PR TITLE
Fix voting visibility

### DIFF
--- a/backend/src/features/suggestion/services/update-vote.js
+++ b/backend/src/features/suggestion/services/update-vote.js
@@ -41,9 +41,7 @@ const updateVote = async ({ id, userId, formData }) => {
         }
 
         const ups = await Suggestions.update(suggestionToVoteOn)
-        const didVote = ups.didVote(userId)
         const ret = ups.toAssociateEditor()
-        ret.voted = didVote
 
         logger.debug("suggestion.vote.finished")
         return ret

--- a/frontend/src/pages/dashboard/board/FinalView.jsx
+++ b/frontend/src/pages/dashboard/board/FinalView.jsx
@@ -120,6 +120,11 @@ const SuggestionContent = ({ suggestion, user }) => {
     const socket = io('http://localhost:3000');
     const [current, setCurrent] = useState(suggestion);
     const [votes, setVotes] = useState(handleVotes(suggestion?.finalDecisions));
+    const checkUserVoted = (s) =>
+        s?.finalDecisions?.some(
+            (v) => v.board_member_id === user.id && v.final_decision !== 'pending'
+        );
+    const [userVoted, setUserVoted] = useState(checkUserVoted(suggestion));
     const options = [
         { label: 'Include', value: 'include' },
         { label: 'Exclude', value: 'exclude' },
@@ -129,6 +134,10 @@ const SuggestionContent = ({ suggestion, user }) => {
         socket.on('update', (newVotes) => {
             setCurrent(newVotes);
             setVotes(handleVotes(newVotes?.finalDecisions));
+            setUserVoted(checkUserVoted(newVotes));
+            if (handleVotes(newVotes?.finalDecisions).pending === 0) {
+                window.location.reload();
+            }
         });
 
         return () => {
@@ -137,6 +146,7 @@ const SuggestionContent = ({ suggestion, user }) => {
     }, []);
 
     const handleVote = (id, formData) => {
+        setUserVoted(true);
         socket.emit('vote', { id, userId: user.id, formData });
     };
     return (
@@ -149,7 +159,7 @@ const SuggestionContent = ({ suggestion, user }) => {
                 <h3>Exclude: {votes.exclude}</h3>
                 <h3>Include: {votes.include}</h3>
                 <h3>Undecided: {votes.pending}</h3>
-                {!current?.voted && (
+                {!userVoted && (
                     <Form
                         //  showConfirmation={{
                         //      defaultInfo: <RecModal />,


### PR DESCRIPTION
## Summary
- ensure board vote updates don't hide form for others
- refresh board page when all votes are in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887515c9780832dbf26713185a0393e