### PR TITLE
Fix deferred review status flow

### DIFF
--- a/backend/src/features/suggestion/models/suggestion.model.js
+++ b/backend/src/features/suggestion/models/suggestion.model.js
@@ -175,6 +175,7 @@ class Suggestion {
             [Actions.DEFERED_TO_REVIEWER]: 'ASSOCIATE_EDITOR_DEFERRED_SUGGESTION_TO_REVIEWER',
             [Actions.ASSIGNED_REVIEWERS]: 'ASSOCIATE_EDITOR_ASSIGNED_REVIEWERS_FOR_FEEDBACK',
             [Actions.RECOMMENDATION_BY_REVIEWER]: 'REVIEWER_SUBMITS_RECOMMENDATION',
+            [Actions.DEFERRED_REVIEW_COMPLETE]: 'REVIEWER_COMPLETED_DEFERRED_SUGGESTION',
             [Actions.ALL_REVIEWS_COMPLETE]: 'ALL_REVIEWERS_FINISH_PROVIDING_FEEDBACK',
             [Actions.STARTED_FINAL_DISCUSSION]: 'EDITOR_IN_CHIEF_BEGINS_BOARD_DISCUSSION',
             [Actions.ACCEPTED_BY_BOARD]: 'BOARD_ACCEPTS_SUGGESTION_CHANGE',
@@ -329,8 +330,13 @@ class Suggestion {
             this.assigned_reviewers.every(r => r.recommendation !== 'pending')
 
         if (allDone) {
-            this._updateStatus(Actions.ALL_REVIEWS_COMPLETE)
-            this.insertHistory(Actions.ALL_REVIEWS_COMPLETE, 'LiveC')
+            if (this.status.for_associate_editor === Status.Private.AssociateEditor.DEFERRED) {
+                this._updateStatus(Actions.DEFERRED_REVIEW_COMPLETE)
+                this.insertHistory(Actions.DEFERRED_REVIEW_COMPLETE, reviewerId)
+            } else {
+                this._updateStatus(Actions.ALL_REVIEWS_COMPLETE)
+                this.insertHistory(Actions.ALL_REVIEWS_COMPLETE, 'LiveC')
+            }
         }
     }
 

--- a/backend/src/shared/constants/index.js
+++ b/backend/src/shared/constants/index.js
@@ -12,6 +12,8 @@ const Actions = Object.freeze({
 
     RECOMMENDATION_BY_REVIEWER: 'recommendation-by-reviewer',
 
+    DEFERRED_REVIEW_COMPLETE: 'deferred-review-complete',
+
     ALL_REVIEWS_COMPLETE: 'all-reviews-complete',
 
     SUBMITTED_BY_MEMBER: 'submitted-by-member',


### PR DESCRIPTION
## Summary
- add `DEFERRED_REVIEW_COMPLETE` action constant
- map new action to the `REVIEWER_COMPLETED_DEFERRED_SUGGESTION` event
- update suggestion model to set `DEFERRED_COMPLETE` when deferred reviewer finishes

## Testing
- `node -c backend/src/shared/constants/index.js`
- `node -c backend/src/features/suggestion/models/suggestion.model.js`
- `npm run docs` *(fails: jsdoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875b1666b0832d883fa018c6f35b89