### PR TITLE
Display suggestion updates as cards

### DIFF
--- a/frontend/src/features/suggestion/UpdateCard.jsx
+++ b/frontend/src/features/suggestion/UpdateCard.jsx
@@ -1,0 +1,46 @@
+import useToggle from '@hooks/useToggle';
+import { formatDate, toTitleCase } from '@utils/format';
+import StatusIcon from '@components/Table/StatusIcon';
+import styles from './UpdateCard.module.scss';
+
+/**
+ * Display a public or internal update as a clickable card.
+ * Expands to show details similar to Message.jsx with Card styling.
+ *
+ * @param {{ update: Object }} props
+ */
+export default function UpdateCard({ update }) {
+    const { toggle, toggleView } = useToggle();
+    const display = toggle ? 'block' : 'none';
+
+    const { status, author, message, date, action, performed_by } = update;
+    const header = status ? (
+        <StatusIcon status={status} />
+    ) : (
+        <span>{toTitleCase(action)}</span>
+    );
+
+    const bodyText = message
+        ? (
+              <>
+                  {author && <strong>{author}</strong>} {message}
+              </>
+          )
+        : (
+              <>
+                  {performed_by && <strong>{performed_by}</strong>} {toTitleCase(action)}
+              </>
+          );
+
+    return (
+        <div className={styles.card} onClick={toggleView}>
+            <div className={styles.header}>
+                {header}
+                <span className={styles.date}>{formatDate(date)}</span>
+            </div>
+            <div className={styles.body} style={{ display }}>
+                {bodyText}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/suggestion/UpdateCard.module.scss
+++ b/frontend/src/features/suggestion/UpdateCard.module.scss
@@ -1,0 +1,28 @@
+@use '@styles' as *;
+
+.card {
+    cursor: pointer;
+    border-radius: 8px;
+    background-color: $stone-200;
+    margin-top: 1rem;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem;
+    border-bottom: 1px solid $gray-200;
+
+    span {
+        font-size: 1rem;
+        font-family: 'Montserrat';
+        font-weight: 500;
+        color: $gray-500;
+    }
+}
+
+.body {
+    padding: 0.75rem 1rem;
+    line-height: 1.5;
+}

--- a/frontend/src/pages/dashboard/suggestion/DefaultView.jsx
+++ b/frontend/src/pages/dashboard/suggestion/DefaultView.jsx
@@ -1,10 +1,9 @@
 import { BackButton } from '@components/buttons';
-import { toTitleCase, formatDate } from '@utils/format';
 import { Grid, Header, SideContent, MainContent } from '@components/layouts/grid/Grid';
 import { postImplementation } from '@utils/api-handlers/suggestions';
 
 import Suggestion from '@features/suggestion/Suggestion';
-import { Message } from '@features/community-member/Message';
+import UpdateCard from '@features/suggestion/UpdateCard';
 import { Form, TextArea } from '@components/input';
 import { useContext, useState } from 'react';
 import { UserContext } from '@context/UserProvider';
@@ -42,7 +41,7 @@ const PublicView = ({ updates }) => {
             <h2>Updates</h2>
             <div>
                 {updates.map((item) => (
-                    <Message key={item.refId} status={item.status} author={item.author} content={item.message} date={item.date} />
+                    <UpdateCard key={item.refId} update={item} />
                 ))}
             </div>
         </>
@@ -55,10 +54,7 @@ const InteralView = ({ history }) => {
             <h2>Updates</h2>
             <div>
                 {history.map((item) => (
-                    <div key={item.performed_by + item.action}>
-                        <p>{toTitleCase(item.action)}</p>
-                        <p>{formatDate(item.date)}</p>
-                    </div>
+                    <UpdateCard key={item.performed_by + item.action} update={item} />
                 ))}
             </div>
         </>


### PR DESCRIPTION
## Summary
- add `UpdateCard` component for suggestions
- style update cards similar to existing Card and Message components
- show public and internal updates in DefaultView using `UpdateCard`

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*
- `node testing/handle-suggestion.error.test.js` *(fails: cannot find module `nanoid`)*

------
https://chatgpt.com/codex/tasks/task_e_68875c52f704832d973d0addc7b8a1d1