### PR TITLE
Enable async lowdb initialization

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,16 @@
 require('module-alias/register');
 const http = require('http');
 const morgan = require('morgan');
-const app = require('./src/app');
+const { app, injectDB: injectAppDB } = require('./src/app');
+const { createDatabases } = require('./src/database/database');
+const Suggestions = require('./src/features/suggestion/models/suggestions.model.js');
+const Curriculums = require('./src/features/curriculum/models/curriculums.model.js');
+const Curriculum = require('./src/features/curriculum/models/curriculum.model.js');
+const CurriculumVersions = require('./src/features/curriculum/models/versions.model.js');
+const Users = require('./src/features/users/models/users/users.model.js');
+const finalizeImplementationService = require('./src/features/suggestion/services/finalize-implementation.js');
+const userInfoUtil = require('./src/shared/utils/getUserInfoById.js');
+const userNameUtil = require('./src/shared/utils/getUserNameById.js');
 const { setupSocketIO } = require('./src/socket');
 const logger = require('./logger/logger.js').addSource({
     file: 'server.js',
@@ -9,21 +18,31 @@ const logger = require('./logger/logger.js').addSource({
 });
 
 const PORT = process.env.PORT || 3000;
-const server = http.createServer(app); // <-- needed for socket.io
 
-// Setup socket.io
-setupSocketIO(server); // see below
+(async () => {
+    const db = await createDatabases();
+    injectAppDB(db);
+    Suggestions.injectDB(db.suggestions);
+    Curriculums.injectDB(db.curriculums);
+    Curriculum.injectDB(db.curriculums);
+    CurriculumVersions.injectDB(db.curriculums);
+    Users.injectDB(db.users);
+    finalizeImplementationService.injectDB(db);
+    userInfoUtil.injectDB(db);
+    userNameUtil.injectDB(db);
 
-// Start server
-server.listen(PORT, () => {
-    logger.info('app.started', { PORT });
-});
+    const server = http.createServer(app); // <-- needed for socket.io
+    setupSocketIO(server); // see below
 
-// Logging
-app.use(
-    morgan('combined', {
-        stream: {
-            write: (msg) => logger.debug(msg.trim()),
-        },
-    })
-);
+    server.listen(PORT, () => {
+        logger.info('app.started', { PORT });
+    });
+
+    app.use(
+        morgan('combined', {
+            stream: {
+                write: (msg) => logger.debug(msg.trim()),
+            },
+        })
+    );
+})();

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,10 @@
 const express = require('express');
 const cors = require('cors')
-const db = require('./database/database');
+let db;
+
+function injectDB(instance) {
+    db = instance;
+}
 const authRoutes = require('./features/auth/routes.js');
 const suggestionRoutes = require('./features/suggestion/routes.js');
 const userRoutes = require('./features/users/routes.js');
@@ -51,4 +55,7 @@ app.use((err, req, res, next) => {
 
 
 
-module.exports = app;
+module.exports = {
+    app,
+    injectDB
+};

--- a/backend/src/database/database.js
+++ b/backend/src/database/database.js
@@ -1,136 +1,127 @@
-const fs = require('fs');
 const path = require('path');
-const { Low } = require('lowdb');
-const { JSONFile } = require('lowdb/node');
 
 const resolve = (...segments) => path.resolve(__dirname, ...segments);
 
+async function createDB(targetPath, defaultJsonPath, { forceReset = false } = {}) {
+  const { Low } = await import('lowdb');
+  const { JSONFile } = await import('lowdb/node');
 
+  const filePath = resolve(targetPath);
+  const defaultData = require(resolve(defaultJsonPath));
+  const adapter = new JSONFile(filePath);
+  const db = new Low(adapter, defaultData);
+  try {
+    await db.read();
+    if (forceReset || !db.data) {
+      db.data = defaultData;
+      await db.write();
+    }
+  } catch (err) {
+    console.warn(`⚠️ Failed to load ${filePath}, reinitializing with defaults.`);
+    db.data = defaultData;
+    await db.write();
+  }
 
-function createDB(targetPath, defaultJsonPath, { forceReset = false } = {}) {
-    const filePath = resolve(targetPath);
-    const defaultData = require(resolve(defaultJsonPath));
-    const adapter = new JSONFile(filePath);
-    const db = new Low(adapter, defaultData);
+  db.reset = async () => {
+    db.data = defaultData;
+    await db.write();
+  };
 
-    (async () => {
-        try {
-            await db.read();
-            if (forceReset || !db.data) {
-                db.data = defaultData;
-                await db.write();
-            }
-        } catch (err) {
-            console.warn(`⚠️ Failed to load ${filePath}, reinitializing with defaults.`);
-            db.data = defaultData;
-            await db.write();
-        }
-
-
-
-    })();
-    db.reset = async () => {
-        db.data = defaultData;
-        await db.write();
-    };
-
-    return db;
+  return db;
 }
 
-
-
-const reset = false
-
-const db = {
+async function createDatabases(options = {}) {
+  const reset = options.forceReset || false;
+  const db = {
     users: {
-        communityMembers: createDB(
-            'data/users/community_member.json',
-            'data/users/default/community_member.json',
-            { forceReset: reset }
-        ),
-        reviewers: createDB(
-            'data/users/reviewer.json',
-            'data/users/default/reviewer.json',
-            { forceReset: reset }
-        ),
-        associateEditors: createDB(
-            'data/users/associate_editor.json',
-            'data/users/default/associate_editor.json',
-            { forceReset: reset }
-        ),
-        chiefEditors: createDB(
-            'data/users/editor_in_chief.json',
-            'data/users/default/editor_in_chief.json',
-            { forceReset: reset }
-        ),
-        admins: createDB(
-            'data/users/admin.json',
-            'data/users/default/admin.json',
-            { forceReset: reset }
-        ),
-        // acmEdBoard: createDB(...), // Uncomment if needed
-    },
-    suggestions: createDB(
-        'data/suggestions/suggestions.json',
-        'data/suggestions/default/suggestions.json',
+      communityMembers: await createDB(
+        'data/users/community_member.json',
+        'data/users/default/community_member.json',
         { forceReset: reset }
+      ),
+      reviewers: await createDB(
+        'data/users/reviewer.json',
+        'data/users/default/reviewer.json',
+        { forceReset: reset }
+      ),
+      associateEditors: await createDB(
+        'data/users/associate_editor.json',
+        'data/users/default/associate_editor.json',
+        { forceReset: reset }
+      ),
+      chiefEditors: await createDB(
+        'data/users/editor_in_chief.json',
+        'data/users/default/editor_in_chief.json',
+        { forceReset: reset }
+      ),
+      admins: await createDB(
+        'data/users/admin.json',
+        'data/users/default/admin.json',
+        { forceReset: reset }
+      ),
+    },
+    suggestions: await createDB(
+      'data/suggestions/suggestions.json',
+      'data/suggestions/default/suggestions.json',
+      { forceReset: reset }
     ),
     curriculums: {
-        computerScience: {
-            tableOfContents: createDB(
-                'data/curriculums/computer-science/table_of_contents.json',
-                'data/curriculums/computer-science/default/table_of_contents.json',
-                { forceReset: reset }
-            ),
-            pageContent: createDB(
-                'data/curriculums/computer-science/page_content.json',
-                'data/curriculums/computer-science/default/page_content.json',
-                { forceReset: reset }
-            ),
-            curriculumVersions: createDB(
-                'data/curriculums/computer-science/versions.json',
-                'data/curriculums/computer-science/default/versions.json',
-                { forceReset: reset }
-            )
-        },
-        cybersecurity: {
-            tableOfContents: createDB(
-                'data/curriculums/cybersecurity/table_of_contents.json',
-                'data/curriculums/cybersecurity/default/table_of_contents.json',
-                { forceReset: reset }
-            ),
-            pageContent: createDB(
-                'data/curriculums/cybersecurity/page_content.json',
-                'data/curriculums/cybersecurity/default/page_content.json',
-                { forceReset: reset }
-            ),
-            curriculumVersions: createDB(
-                'data/curriculums/cybersecurity/versions.json',
-                'data/curriculums/cybersecurity/default/versions.json',
-                { forceReset: reset }
-            )
-        },
+      computerScience: {
+        tableOfContents: await createDB(
+          'data/curriculums/computer-science/table_of_contents.json',
+          'data/curriculums/computer-science/default/table_of_contents.json',
+          { forceReset: reset }
+        ),
+        pageContent: await createDB(
+          'data/curriculums/computer-science/page_content.json',
+          'data/curriculums/computer-science/default/page_content.json',
+          { forceReset: reset }
+        ),
+        curriculumVersions: await createDB(
+          'data/curriculums/computer-science/versions.json',
+          'data/curriculums/computer-science/default/versions.json',
+          { forceReset: reset }
+        ),
+      },
+      cybersecurity: {
+        tableOfContents: await createDB(
+          'data/curriculums/cybersecurity/table_of_contents.json',
+          'data/curriculums/cybersecurity/default/table_of_contents.json',
+          { forceReset: reset }
+        ),
+        pageContent: await createDB(
+          'data/curriculums/cybersecurity/page_content.json',
+          'data/curriculums/cybersecurity/default/page_content.json',
+          { forceReset: reset }
+        ),
+        curriculumVersions: await createDB(
+          'data/curriculums/cybersecurity/versions.json',
+          'data/curriculums/cybersecurity/default/versions.json',
+          { forceReset: reset }
+        ),
+      },
+    },
+  };
 
-    }
-}
-async function resetAll() {
+  async function resetAll() {
     await Promise.all([
-        db.users.communityMembers.reset(),
-        db.users.reviewers.reset(),
-        db.users.associateEditors.reset(),
-        db.users.chiefEditors.reset(),
-        db.users.admins.reset(),
-        db.suggestions.reset(),
-        db.curriculums.computerScience.tableOfContents.reset(),
-        db.curriculums.computerScience.pageContent.reset(),
-        db.curriculums.computerScience.curriculumVersions.reset(),
-        db.curriculums.cybersecurity.tableOfContents.reset(),
-        db.curriculums.cybersecurity.pageContent.reset(),
-        db.curriculums.cybersecurity.curriculumVersions.reset(),
-
+      db.users.communityMembers.reset(),
+      db.users.reviewers.reset(),
+      db.users.associateEditors.reset(),
+      db.users.chiefEditors.reset(),
+      db.users.admins.reset(),
+      db.suggestions.reset(),
+      db.curriculums.computerScience.tableOfContents.reset(),
+      db.curriculums.computerScience.pageContent.reset(),
+      db.curriculums.computerScience.curriculumVersions.reset(),
+      db.curriculums.cybersecurity.tableOfContents.reset(),
+      db.curriculums.cybersecurity.pageContent.reset(),
+      db.curriculums.cybersecurity.curriculumVersions.reset(),
     ]);
+  }
+
+  db.resetAll = resetAll;
+  return db;
 }
 
-// Attach resetAll to exported db for manual resets
-db.resetAll = resetAll;
-module.exports = db;
+module.exports = { createDB, createDatabases };

--- a/backend/src/features/curriculum/models/curriculum.model.js
+++ b/backend/src/features/curriculum/models/curriculum.model.js
@@ -1,7 +1,10 @@
-const db = require('../../../database/database');
-
 class Curriculum {
-    dbRef = db.curriculums
+    static dbRef;
+
+    static injectDB(dbInstance) {
+        this.dbRef = dbInstance;
+    }
+
     constructor(ref) {
         this.currRef = ref
 

--- a/backend/src/features/curriculum/models/curriculums.model.js
+++ b/backend/src/features/curriculum/models/curriculums.model.js
@@ -1,11 +1,14 @@
-const db = require('../../../database/database');
 const { flattenSections } = require('../../../../../docs/shared/utils/flatten.js');
 const Curriculum = require('./curriculum.model');
 
 
 
 class Curriculums {
-    static dbRef = db.curriculums;
+    static dbRef;
+
+    static injectDB(dbInstance) {
+        this.dbRef = dbInstance;
+    }
 
 
     /**

--- a/backend/src/features/curriculum/models/versions.model.js
+++ b/backend/src/features/curriculum/models/versions.model.js
@@ -1,8 +1,11 @@
-const db = require('../../../database/database');
 const CurriculumVersion = require('./curriculum-version.model');
 const kebabToCamel = require('../../../shared/utils/kebabToCamel');
 class CurriculumVersions {
-    static dbRef = db.curriculums;
+    static dbRef;
+
+    static injectDB(dbInstance) {
+        this.dbRef = dbInstance;
+    }
 
     static async getAll(curriculum) {
         await this.dbRef[curriculum].curriculumVersions.read();
@@ -25,7 +28,7 @@ class CurriculumVersions {
         let found = this.dbRef[curriculum].curriculumVersions.data.find(v => v.id === id);
 
         if (!found) {
-            const tocRef = db.curriculums?.[curriculum]?.tableOfContents;
+            const tocRef = this.dbRef?.[curriculum]?.tableOfContents;
             if (tocRef) {
                 await tocRef.read();
                 const exists = tocRef.data.some(section =>

--- a/backend/src/features/suggestion/models/suggestions.model.js
+++ b/backend/src/features/suggestion/models/suggestions.model.js
@@ -1,10 +1,13 @@
-const db = require('../../../database/database');
 const Suggestion = require('./suggestion.model');
 const { Roles } = require('../../../../../docs/constants/roles.js');
 const { Status } = require('../../../../../docs/constants/status.js');
 
 class Suggestions {
-    static dbRef = db.suggestions;
+    static dbRef;
+
+    static injectDB(dbInstance) {
+        this.dbRef = dbInstance;
+    }
 
 
     /**

--- a/backend/src/features/suggestion/services/finalize-implementation.js
+++ b/backend/src/features/suggestion/services/finalize-implementation.js
@@ -6,7 +6,11 @@ const {
 const addCurriculumVersion = require('../../curriculum/services/add-version');
 const { generateSectionId } = require('../../../shared/utils/generate-id');
 const kebabToCamel = require('../../../shared/utils/kebabToCamel');
-const db = require('../../../database/database');
+let db;
+
+function injectDB(instance) {
+    db = instance;
+}
 
 const logger = require('../../../../logger/logger.js').addSource({
     file: 'suggestion.service',
@@ -99,4 +103,7 @@ const finalizeImplementation = async (id, eicId, notes, message) => {
     }
 };
 
-module.exports = finalizeImplementation;
+module.exports = {
+    finalizeImplementation,
+    injectDB
+};

--- a/backend/src/features/users/models/users/users.model.js
+++ b/backend/src/features/users/models/users/users.model.js
@@ -1,10 +1,14 @@
 // models/Users.js
-const db = require('../../../../database/database');
 
 class Users {
+    static dbRef;
+
+    static injectDB(dbInstance) {
+        this.dbRef = dbInstance;
+    }
 
     static getDbRef() {
-        const dbRef = db.users[this.roleKey];
+        const dbRef = this.dbRef[this.roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${this.roleKey}`);
         return dbRef;
     }
@@ -31,7 +35,7 @@ class Users {
         const registry = this.getRegistry();
 
         for (const [roleKey, CollectionClass] of Object.entries(registry)) {
-            const dbRef = db.users[roleKey];
+            const dbRef = this.dbRef[roleKey];
             if (!dbRef) continue;
 
             await dbRef.read();
@@ -51,7 +55,7 @@ class Users {
         const registry = this.getRegistry();
 
         for (const roleKey of Object.keys(registry)) {
-            const dbRef = db.users[roleKey];
+            const dbRef = this.dbRef[roleKey];
             if (!dbRef) continue;
 
             await dbRef.read();
@@ -71,7 +75,7 @@ class Users {
      * Role-specific: get all users for this subclass
      */
     static async getAll() {
-        const dbRef = db.users[this.roleKey];
+        const dbRef = this.dbRef[this.roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${this.roleKey}`);
 
         await dbRef.read();
@@ -82,7 +86,7 @@ class Users {
      * Role-specific: find one user by ID
      */
     static async findById(id) {
-        const dbRef = db.users[this.roleKey];
+        const dbRef = this.dbRef[this.roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${this.roleKey}`);
 
         await dbRef.read();
@@ -94,7 +98,7 @@ class Users {
      * Role-specific: find one user by email
      */
     static async findByEmail(email) {
-        const dbRef = db.users[this.roleKey];
+        const dbRef = this.dbRef[this.roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${this.roleKey}`);
 
         await dbRef.read();
@@ -114,7 +118,7 @@ class Users {
      * Role-specific: update an existing user instance
      */
     static async update(userInstance) {
-        const dbRef = db.users[this.roleKey];
+        const dbRef = this.dbRef[this.roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${this.roleKey}`);
 
         await dbRef.read();
@@ -132,7 +136,7 @@ class Users {
      * Internal helper to insert based on roleKey
      */
     static async _insertFromRole(roleKey, userInstance) {
-        const dbRef = db.users[roleKey];
+        const dbRef = this.dbRef[roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${roleKey}`);
 
         await dbRef.read();
@@ -146,7 +150,7 @@ class Users {
      * Internal helper to get all users for a specific roleKey/Model
      */
     static async _getFromRole(roleKey, Model) {
-        const dbRef = db.users[roleKey];
+        const dbRef = this.dbRef[roleKey];
         if (!dbRef) throw new Error(`No DB found for role: ${roleKey}`);
 
         await dbRef.read();

--- a/backend/src/shared/utils/getUserInfoById.js
+++ b/backend/src/shared/utils/getUserInfoById.js
@@ -1,4 +1,8 @@
-const db = require('../../database/database');
+let db;
+
+function injectDB(instance) {
+    db = instance;
+}
 
 const roleMap = {
     CM: 'communityMembers',
@@ -19,4 +23,7 @@ async function getUserInfoById(id) {
     return found ? { name: found.name, role: found.role } : { name: id, role: 'unknown' };
 }
 
-module.exports = getUserInfoById;
+module.exports = {
+    getUserInfoById,
+    injectDB
+};

--- a/backend/src/shared/utils/getUserNameById.js
+++ b/backend/src/shared/utils/getUserNameById.js
@@ -1,4 +1,8 @@
-const db = require('../../database/database');
+let db;
+
+function injectDB(instance) {
+    db = instance;
+}
 
 const roleMap = {
     CM: 'communityMembers',
@@ -19,4 +23,7 @@ async function getUserNameById(id) {
     return found ? found.name : id;
 }
 
-module.exports = getUserNameById;
+module.exports = {
+    getUserNameById,
+    injectDB
+};


### PR DESCRIPTION
## Summary
- refactor database.js for async lowdb init
- add new `createDatabases` helper
- allow models/services to inject database references
- initialize and inject DBs in server startup

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6887c710f2f0832d9e7db2f74c0ea2ca