### PR TITLE
Convert backend requires to ES module imports

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,14 +1,14 @@
-const express = require('express');
-const cors = require('cors')
+import express from 'express';
+import cors from 'cors';
 let db;
 
 function injectDB(instance) {
     db = instance;
 }
-const authRoutes = require('./features/auth/routes.js');
-const suggestionRoutes = require('./features/suggestion/routes.js');
-const userRoutes = require('./features/users/routes.js');
-const curriculumRoutes = require('./features/curriculum/routes.js');
+import authRoutes from './features/auth/routes.js';
+import suggestionRoutes from './features/suggestion/routes.js';
+import userRoutes from './features/users/routes.js';
+import curriculumRoutes from './features/curriculum/routes.js';
 
 const app = express();
 app.use(express.json());

--- a/backend/src/database/database.js
+++ b/backend/src/database/database.js
@@ -1,4 +1,4 @@
-const path = require('path');
+import path from 'path';
 
 const resolve = (...segments) => path.resolve(__dirname, ...segments);
 

--- a/backend/src/features/auth/controllers/index.js
+++ b/backend/src/features/auth/controllers/index.js
@@ -1,5 +1,5 @@
-const { postLogin } = require('./post-login');
-const { postRegister } = require('./post-register');
+import {  postLogin  } from './post-login';
+import {  postRegister  } from './post-register';
 
 
 module.exports = { postLogin, postRegister }

--- a/backend/src/features/auth/controllers/post-login.js
+++ b/backend/src/features/auth/controllers/post-login.js
@@ -1,7 +1,8 @@
-const { handleLoginUser } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleLoginUser } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.controller',
     method: "postLogin",
     params: ["req.body"]

--- a/backend/src/features/auth/controllers/post-register.js
+++ b/backend/src/features/auth/controllers/post-register.js
@@ -1,7 +1,8 @@
-const { handleRegisterUser } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleRegisterUser } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.controller',
     method: "postRegister",
     params: ["req.body"]

--- a/backend/src/features/auth/routes.js
+++ b/backend/src/features/auth/routes.js
@@ -1,6 +1,6 @@
-const express = require('express');
+import express from 'express';
 
-const { postLogin, postRegister } = require('./controllers');
+import {  postLogin, postRegister  } from './controllers';
 
 const router = express.Router();
 

--- a/backend/src/features/auth/services/handle-login.js
+++ b/backend/src/features/auth/services/handle-login.js
@@ -1,7 +1,8 @@
-const { UserNotFoundError, PasswordMismatchError, AppError } = require('../../../shared/errors');
-const Users = require('../../users/models/users/users.model.js')
+import { UserNotFoundError, PasswordMismatchError, AppError } from '../../../shared/errors';
+import Users from '../../users/models/users/users.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "handleLoginUser",
     params: ["email, password"]

--- a/backend/src/features/auth/services/handle-register.js
+++ b/backend/src/features/auth/services/handle-register.js
@@ -1,8 +1,9 @@
-const CommunityMembers = require('../../users/models/users/community-member/members.model');
-const { UserAlreadyExistsError, AppError } = require('../../../shared/errors');
-const Users = require('../../users/models/users/users.model')
+import CommunityMembers from '../../users/models/users/community-member/members.model.js';
+import { UserAlreadyExistsError, AppError } from '../../../shared/errors';
+import Users from '../../users/models/users/users.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "handleRegisterUser",
     params: ["name", "email", "password"]

--- a/backend/src/features/auth/services/index.js
+++ b/backend/src/features/auth/services/index.js
@@ -1,5 +1,4 @@
-const { handleLoginUser } = require('./handle-login')
-const { handleRegisterUser } = require('./handle-register')
+import { handleLoginUser } from './handle-login';
+import { handleRegisterUser } from './handle-register';
 
-
-module.exports = { handleLoginUser, handleRegisterUser }
+module.exports = { handleLoginUser, handleRegisterUser };

--- a/backend/src/features/curriculum/controllers/get-curriculum.js
+++ b/backend/src/features/curriculum/controllers/get-curriculum.js
@@ -1,7 +1,8 @@
-const  getFullCurriculum  = require('../services/get-one')
-const { AppError } = require('../../../shared/errors');
+import getFullCurriculum from '../services/get-one';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'curriculum.controller',
     method: "getCurriculum",
     params: ['req.body']

--- a/backend/src/features/curriculum/controllers/get-section.js
+++ b/backend/src/features/curriculum/controllers/get-section.js
@@ -1,6 +1,7 @@
-const { getCurriculumSection } = require('../services');
-const { AppError } = require('../../../shared/errors');
-const logger = require('../../../../logger/logger.js').addSource({ file: 'curriculum.controller', method: 'getSection' });
+import { getCurriculumSection } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({ file: 'curriculum.controller', method: 'getSection' });
 
 const getSection = async (req, res) => {
     try {

--- a/backend/src/features/curriculum/controllers/get-version.js
+++ b/backend/src/features/curriculum/controllers/get-version.js
@@ -1,6 +1,7 @@
-const { getCurriculumVersion } = require('../services');
-const { AppError } = require('../../../shared/errors');
-const logger = require('../../../../logger/logger.js').addSource({ file: 'curriculum.controller', method: 'getVersion' });
+import { getCurriculumVersion } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({ file: 'curriculum.controller', method: 'getVersion' });
 
 const getVersion = async (req, res) => {
     try {

--- a/backend/src/features/curriculum/controllers/index.js
+++ b/backend/src/features/curriculum/controllers/index.js
@@ -1,7 +1,7 @@
-const { getCurriculum } = require('./get-curriculum')
-const { getSection } = require('./get-section')
-const { updateSection } = require('./update-section')
-const { postVersion } = require('./post-version')
-const { getVersion } = require('./get-version')
+import { getCurriculum } from './get-curriculum';
+import { getSection } from './get-section';
+import { updateSection } from './update-section';
+import { postVersion } from './post-version';
+import { getVersion } from './get-version';
 
-module.exports = { getCurriculum, getSection, updateSection, postVersion, getVersion }
+module.exports = { getCurriculum, getSection, updateSection, postVersion, getVersion };

--- a/backend/src/features/curriculum/controllers/post-version.js
+++ b/backend/src/features/curriculum/controllers/post-version.js
@@ -1,6 +1,7 @@
-const { addCurriculumVersion } = require('../services');
-const { AppError } = require('../../../shared/errors');
-const logger = require('../../../../logger/logger.js').addSource({ file: 'curriculum.controller', method: 'postVersion' });
+import { addCurriculumVersion } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({ file: 'curriculum.controller', method: 'postVersion' });
 
 const postVersion = async (req, res) => {
     try {

--- a/backend/src/features/curriculum/controllers/update-section.js
+++ b/backend/src/features/curriculum/controllers/update-section.js
@@ -1,6 +1,7 @@
-const { updateCurriculumSection } = require('../services');
-const { AppError } = require('../../../shared/errors');
-const logger = require('../../../../logger/logger.js').addSource({ file: 'curriculum.controller', method: 'updateSection' });
+import { updateCurriculumSection } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({ file: 'curriculum.controller', method: 'updateSection' });
 
 const updateSection = async (req, res) => {
     try {

--- a/backend/src/features/curriculum/models/change-set.model.js
+++ b/backend/src/features/curriculum/models/change-set.model.js
@@ -1,4 +1,4 @@
-const { nanoid } = require('nanoid');
+import {  nanoid  } from 'nanoid';
 
 class ChangeSet {
     constructor(data = {}) {

--- a/backend/src/features/curriculum/models/curriculum-version.model.js
+++ b/backend/src/features/curriculum/models/curriculum-version.model.js
@@ -1,4 +1,4 @@
-const { nanoid } = require('nanoid');
+import {  nanoid  } from 'nanoid';
 
 class CurriculumVersion {
     constructor(data = {}) {

--- a/backend/src/features/curriculum/models/curriculums.model.js
+++ b/backend/src/features/curriculum/models/curriculums.model.js
@@ -1,5 +1,5 @@
-const { flattenSections } = require('../../../../../docs/shared/utils/flatten.js');
-const Curriculum = require('./curriculum.model');
+import {  flattenSections  } from '../../../../../docs/shared/utils/flatten.js';
+import Curriculum from './curriculum.model';
 
 
 

--- a/backend/src/features/curriculum/models/versions.model.js
+++ b/backend/src/features/curriculum/models/versions.model.js
@@ -1,5 +1,5 @@
-const CurriculumVersion = require('./curriculum-version.model');
-const kebabToCamel = require('../../../shared/utils/kebabToCamel');
+import CurriculumVersion from './curriculum-version.model';
+import kebabToCamel from '../../../shared/utils/kebabToCamel';
 class CurriculumVersions {
     static dbRef;
 

--- a/backend/src/features/curriculum/routes.js
+++ b/backend/src/features/curriculum/routes.js
@@ -1,8 +1,7 @@
-const express = require('express');
-const { getCurriculum, getSection, updateSection, postVersion, getVersion } = require('./controllers')
+import express from 'express';
+import { getCurriculum, getSection, updateSection, postVersion, getVersion } from './controllers';
 
 const router = express.Router();
-
 
 router.get('/:curriculum', getCurriculum);
 router.get('/:curriculum/sections/:sectionId', getSection);

--- a/backend/src/features/curriculum/services/add-version.js
+++ b/backend/src/features/curriculum/services/add-version.js
@@ -1,4 +1,4 @@
-const CurriculumVersions = require('../models/versions.model');
+import CurriculumVersions from '../models/versions.model';
 
 const addCurriculumVersion = async (curriculum, versionData) => {
     return CurriculumVersions.insert(curriculum, versionData);

--- a/backend/src/features/curriculum/services/get-one.js
+++ b/backend/src/features/curriculum/services/get-one.js
@@ -1,11 +1,12 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
 
-const Suggestions = require('../../suggestion/models/suggestions.model.js')
-const Curriculums = require('../models/curriculums.model.js')
-const kebabToCamel = require('../../../shared/utils/kebabToCamel')
+import Suggestions from '../../suggestion/models/suggestions.model.js';
+import Curriculums from '../models/curriculums.model.js';
+import kebabToCamel from '../../../shared/utils/kebabToCamel.js';
+import baseLogger from '../../../../logger/logger.js';
 
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "assignAssociateEditorToSuggestion",
     params: ['suggestion']

--- a/backend/src/features/curriculum/services/get-section.js
+++ b/backend/src/features/curriculum/services/get-section.js
@@ -1,5 +1,5 @@
-const Curriculums = require('../models/curriculums.model.js');
-const kebabToCamel = require('../../../shared/utils/kebabToCamel');
+import Curriculums from '../models/curriculums.model.js';
+import kebabToCamel from '../../../shared/utils/kebabToCamel';
 
 const getCurriculumSection = async (curriculum, id) => {
     const curr = await Curriculums.findByCurriculum(kebabToCamel(curriculum));

--- a/backend/src/features/curriculum/services/get-version.js
+++ b/backend/src/features/curriculum/services/get-version.js
@@ -1,9 +1,10 @@
-const CurriculumVersions = require('../models/versions.model');
-const { AppError } = require('../../../shared/errors');
-const kebabToCamel = require('../../../shared/utils/kebabToCamel')
+import CurriculumVersions from '../models/versions.model';
+import {  AppError  } from '../../../shared/errors';
+import kebabToCamel from '../../../shared/utils/kebabToCamel.js';
 
 
-const logger = require('../../../../logger/logger.js').addSource({
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "getCurriculumVersion",
     params: ['curriculum', 'versionId']

--- a/backend/src/features/curriculum/services/index.js
+++ b/backend/src/features/curriculum/services/index.js
@@ -1,8 +1,8 @@
-const getFullCurriculum = require('./get-one');
-const getCurriculumSection = require('./get-section');
-const updateCurriculumSection = require('./update-section');
-const addCurriculumVersion = require('./add-version');
-const getCurriculumVersion = require('./get-version');
+import getFullCurriculum from './get-one';
+import getCurriculumSection from './get-section';
+import updateCurriculumSection from './update-section';
+import addCurriculumVersion from './add-version';
+import getCurriculumVersion from './get-version';
 
 module.exports = {
     getFullCurriculum,

--- a/backend/src/features/curriculum/services/update-section.js
+++ b/backend/src/features/curriculum/services/update-section.js
@@ -1,5 +1,5 @@
-const Curriculums = require('../models/curriculums.model.js');
-const kebabToCamel = require('../../../shared/utils/kebabToCamel');
+import Curriculums from '../models/curriculums.model.js';
+import kebabToCamel from '../../../shared/utils/kebabToCamel';
 
 const updateCurriculumSection = async (curriculum, section) => {
     const curr = await Curriculums.findByCurriculum(kebabToCamel(curriculum));

--- a/backend/src/features/suggestion/controllers/get-suggestion.js
+++ b/backend/src/features/suggestion/controllers/get-suggestion.js
@@ -1,7 +1,8 @@
-const { getSuggestionById } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { getSuggestionById } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "getSuggestion",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-approval.js
+++ b/backend/src/features/suggestion/controllers/post-approval.js
@@ -1,8 +1,9 @@
 
-const { handleEditorInChiefApproval } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleEditorInChiefApproval } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postEditorInChiefApproval",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-change.js
+++ b/backend/src/features/suggestion/controllers/post-change.js
@@ -1,8 +1,9 @@
 
-const { sendChangeRequestToAssociateEditor } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { sendChangeRequestToAssociateEditor } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postChangeRequest",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-deferral.js
+++ b/backend/src/features/suggestion/controllers/post-deferral.js
@@ -1,7 +1,8 @@
-const { handleDeferSuggestionToReviewer } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleDeferSuggestionToReviewer } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postDeferral",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-discussion.js
+++ b/backend/src/features/suggestion/controllers/post-discussion.js
@@ -1,7 +1,8 @@
-const { handleFinalDiscussion } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleFinalDiscussion } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postDiscussion",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-documentation.js
+++ b/backend/src/features/suggestion/controllers/post-documentation.js
@@ -1,7 +1,8 @@
-const { addNewDocumentationToSuggestion } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { addNewDocumentationToSuggestion } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postDocumentation",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-finalized.js
+++ b/backend/src/features/suggestion/controllers/post-finalized.js
@@ -1,7 +1,8 @@
-const { associateEditorFinalized } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { associateEditorFinalized } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postSuggestion",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-implementation.js
+++ b/backend/src/features/suggestion/controllers/post-implementation.js
@@ -1,6 +1,7 @@
-const { finalizeImplementation } = require('../services');
-const { AppError } = require('../../../shared/errors');
-const logger = require('../../../../logger/logger.js').addSource({ file: 'suggestion.controller', method: 'postImplementation' });
+import { finalizeImplementation } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({ file: 'suggestion.controller', method: 'postImplementation' });
 
 const postImplementation = async (req, res) => {
     try {

--- a/backend/src/features/suggestion/controllers/post-recommendation.js
+++ b/backend/src/features/suggestion/controllers/post-recommendation.js
@@ -1,7 +1,8 @@
-const { addRecommendationFromReviewer } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { addRecommendationFromReviewer } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postRecommednation",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-reject.js
+++ b/backend/src/features/suggestion/controllers/post-reject.js
@@ -1,7 +1,8 @@
-const { handleRejectSuggestion } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleRejectSuggestion } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postSuggestion",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-reviewers.js
+++ b/backend/src/features/suggestion/controllers/post-reviewers.js
@@ -1,7 +1,8 @@
-const { assignReviewersToSuggestion } =require('../services')
-const { AppError } = require('../../../shared/errors');
+import { assignReviewersToSuggestion } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postReviewers",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-start.js
+++ b/backend/src/features/suggestion/controllers/post-start.js
@@ -1,7 +1,8 @@
-const { handleStartSuggestionReviewProcess } = require('../services')
-const { AppError } = require('../../../shared/errors');
+import { handleStartSuggestionReviewProcess } from '../services';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller',
     method: "postStartReview",
     params: ['req.body']

--- a/backend/src/features/suggestion/controllers/post-suggestion.js
+++ b/backend/src/features/suggestion/controllers/post-suggestion.js
@@ -1,7 +1,8 @@
-const  handleNewSuggestion  = require('../services/handle-suggestion.js')
-const { AppError } = require('../../../shared/errors');
+import handleNewSuggestion from '../services/handle-suggestion.js';
+import { AppError } from '../../../shared/errors';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.controller', 
     method: "postSuggestion", 
     params: ['req.body']

--- a/backend/src/features/suggestion/models/suggestion.model.js
+++ b/backend/src/features/suggestion/models/suggestion.model.js
@@ -1,9 +1,9 @@
-const { generateSuggestionId } = require('../../../shared/utils/generate-id');
-const { Actions } = require('../../../shared/constants');
-const { Status } = require('../../../../../docs/constants/status.js');
-const { Events } = require('../../../../../docs/events.js');
-const Documentation = require('./util/documentation.model')
-const PublicMessage = require('./util/public-message.model')
+import {  generateSuggestionId  } from '../../../shared/utils/generate-id';
+import {  Actions  } from '../../../shared/constants';
+import {  Status  } from '../../../../../docs/constants/status.js';
+import {  Events  } from '../../../../../docs/events.js';
+import Documentation from './util/documentation.model.js';
+import PublicMessage from './util/public-message.model.js';
 
 
 class Suggestion {

--- a/backend/src/features/suggestion/models/suggestions.model.js
+++ b/backend/src/features/suggestion/models/suggestions.model.js
@@ -1,6 +1,6 @@
-const Suggestion = require('./suggestion.model');
-const { Roles } = require('../../../../../docs/constants/roles.js');
-const { Status } = require('../../../../../docs/constants/status.js');
+import Suggestion from './suggestion.model';
+import {  Roles  } from '../../../../../docs/constants/roles.js';
+import {  Status  } from '../../../../../docs/constants/status.js';
 
 class Suggestions {
     static dbRef;

--- a/backend/src/features/suggestion/models/util/documentation.model.js
+++ b/backend/src/features/suggestion/models/util/documentation.model.js
@@ -1,5 +1,5 @@
-const { generateRandomId } = require('../../../../shared/utils/generate-id');
-const { Actions } = require('../../../../shared/constants')
+import { generateRandomId } from '../../../../shared/utils/generate-id';
+import { Actions } from '../../../../shared/constants';
 
 const defaultAction = Actions.ADDED_DOCUMENTATION
 

--- a/backend/src/features/suggestion/models/util/public-message.model.js
+++ b/backend/src/features/suggestion/models/util/public-message.model.js
@@ -1,4 +1,4 @@
-const { generateRandomId } = require('../../../../shared/utils/generate-id'); 
+import {  generateRandomId  } from '../../../../shared/utils/generate-id'; 
 
 class PublicMessage {
     constructor({refId = generateRandomId(), status, date = new Date().toISOString(), message, author = 'LiveC'}) {

--- a/backend/src/features/suggestion/routes.js
+++ b/backend/src/features/suggestion/routes.js
@@ -1,11 +1,19 @@
-const express = require('express');
-
-const {
-    postSuggestion, postRejection, getSuggestion,
-    postStartReview, postAssignReviewers, postDocumentation,
-    postAssociateEditorFinalization, postEditorInChiefApproval,
-    postChangeRequest, postDeferral, postRecommednation, postDiscussion, postImplementation
-} = require('./controllers');
+import express from 'express';
+import {
+    postSuggestion,
+    postRejection,
+    getSuggestion,
+    postStartReview,
+    postAssignReviewers,
+    postDocumentation,
+    postAssociateEditorFinalization,
+    postEditorInChiefApproval,
+    postChangeRequest,
+    postDeferral,
+    postRecommednation,
+    postDiscussion,
+    postImplementation,
+} from './controllers';
 
 const router = express.Router();
 

--- a/backend/src/features/suggestion/services/add-documentation.js
+++ b/backend/src/features/suggestion/services/add-documentation.js
@@ -1,7 +1,8 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "addNewDocumentationToSuggestion",
     params: ['suggestionId', 'author', 'markdownText']

--- a/backend/src/features/suggestion/services/assign-editor.js
+++ b/backend/src/features/suggestion/services/assign-editor.js
@@ -1,8 +1,9 @@
-const { AppError, NoAssociateEditorsFoundError } = require('../../../shared/errors');
-const AssociateEditors = require('../../users/models/users/associate-editor/editors.model.js')
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, NoAssociateEditorsFoundError } from '../../../shared/errors';
+import AssociateEditors from '../../users/models/users/associate-editor/editors.model.js';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "assignAssociateEditorToSuggestion",
     params: ['suggestion']

--- a/backend/src/features/suggestion/services/assign-reviewers.js
+++ b/backend/src/features/suggestion/services/assign-reviewers.js
@@ -1,8 +1,9 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Reviewers = require('../../users/models/users/reviewer/reviewers.model.js')
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Reviewers from '../../users/models/users/reviewer/reviewers.model.js';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "assignReviewersToSuggestion",
     params: ['suggestionId, notes, message, reviewers']

--- a/backend/src/features/suggestion/services/finalize-implementation.js
+++ b/backend/src/features/suggestion/services/finalize-implementation.js
@@ -1,18 +1,17 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js');
-const {
-    getCurriculumSection,
-} = require('../../curriculum/services');
-const addCurriculumVersion = require('../../curriculum/services/add-version');
-const { generateSectionId } = require('../../../shared/utils/generate-id');
-const kebabToCamel = require('../../../shared/utils/kebabToCamel');
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import { getCurriculumSection } from '../../curriculum/services';
+import addCurriculumVersion from '../../curriculum/services/add-version.js';
+import { generateSectionId } from '../../../shared/utils/generate-id';
+import kebabToCamel from '../../../shared/utils/kebabToCamel.js';
+import baseLogger from '../../../../logger/logger.js';
 let db;
 
 function injectDB(instance) {
     db = instance;
 }
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: 'finalizeImplementation',
     params: ['suggestionId', 'eicId', 'notes', 'message']

--- a/backend/src/features/suggestion/services/finalize.js
+++ b/backend/src/features/suggestion/services/finalize.js
@@ -1,8 +1,9 @@
-const { AppError, SuggestionNotFoundError, NoUserWithIdError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
-const EditorsInChief = require('../../users/models/users/editor-in-chief/chiefs.model')
+import { AppError, SuggestionNotFoundError, NoUserWithIdError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import EditorsInChief from '../../users/models/users/editor-in-chief/chiefs.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "associateEditorFinalized",
     params: ['suggestionId', 'author', 'markdownText']

--- a/backend/src/features/suggestion/services/get-one.js
+++ b/backend/src/features/suggestion/services/get-one.js
@@ -1,11 +1,12 @@
-const { AppError, NoAssociateEditorsFoundError, SuggestionNotFoundError } = require('../../../shared/errors');
-const { Roles } = require('../../../../../docs/constants/roles.js')
-const Suggestions = require('../models/suggestions.model.js')
-const Curriculums = require('../../curriculum/models/curriculums.model.js')
-const kebabToCamel = require('../../../shared/utils/kebabToCamel')
-const { getUserNameById } = require('../../../shared/utils/getUserNameById')
-const { getUserInfoById } = require('../../../shared/utils/getUserInfoById')
-const logger = require('../../../../logger/logger.js').addSource({
+import { AppError, NoAssociateEditorsFoundError, SuggestionNotFoundError } from '../../../shared/errors';
+import { Roles } from '../../../../../docs/constants/roles.js';
+import Suggestions from '../models/suggestions.model.js';
+import Curriculums from '../../curriculum/models/curriculums.model.js';
+import kebabToCamel from '../../../shared/utils/kebabToCamel.js';
+import { getUserNameById } from '../../../shared/utils/getUserNameById';
+import { getUserInfoById } from '../../../shared/utils/getUserInfoById';
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "assignAssociateEditorToSuggestion",
     params: ['suggestion']

--- a/backend/src/features/suggestion/services/handle-approval.js
+++ b/backend/src/features/suggestion/services/handle-approval.js
@@ -1,8 +1,9 @@
-const { AppError, SuggestionNotFoundError, NoUserWithIdError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
-const EditorsInChief = require('../../users/models/users/editor-in-chief/chiefs.model')
+import { AppError, SuggestionNotFoundError, NoUserWithIdError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import EditorsInChief from '../../users/models/users/editor-in-chief/chiefs.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "handleEditorInChiefApproval",
     params: ['suggestionId', 'author', 'markdownText']

--- a/backend/src/features/suggestion/services/handle-deferral.js
+++ b/backend/src/features/suggestion/services/handle-deferral.js
@@ -1,8 +1,9 @@
-const { AppError, SuggestionNotFoundError, UserNotFoundError } = require('../../../shared/errors');
-const Reviewers = require('../../users/models/users/reviewer/reviewers.model.js')
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, SuggestionNotFoundError, UserNotFoundError } from '../../../shared/errors';
+import Reviewers from '../../users/models/users/reviewer/reviewers.model.js';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "handleDeferSuggestionToReviewer",
     params: ['id', 'reviewerId']

--- a/backend/src/features/suggestion/services/handle-discussion.js
+++ b/backend/src/features/suggestion/services/handle-discussion.js
@@ -1,9 +1,10 @@
-const { AppError, SuggestionNotFoundError, NoUserWithIdError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
-const EditorsInChief = require('../../users/models/users/editor-in-chief/chiefs.model')
-const AssociateEditors = require('../../users/models/users/associate-editor/editors.model.js')
+import { AppError, SuggestionNotFoundError, NoUserWithIdError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import EditorsInChief from '../../users/models/users/editor-in-chief/chiefs.model.js';
+import AssociateEditors from '../../users/models/users/associate-editor/editors.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "handleFinalDiscussion",
     params: ['suggestionId', 'author', 'markdownText']

--- a/backend/src/features/suggestion/services/handle-recommendation.js
+++ b/backend/src/features/suggestion/services/handle-recommendation.js
@@ -1,8 +1,9 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Reviewers = require('../../users/models/users/reviewer/reviewers.model.js')
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Reviewers from '../../users/models/users/reviewer/reviewers.model.js';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "addRecommendationFromReviewer",
     params: ['id', 'reviewerId']

--- a/backend/src/features/suggestion/services/handle-reject.js
+++ b/backend/src/features/suggestion/services/handle-reject.js
@@ -1,9 +1,10 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
 
 
 
-const logger = require('../../../../logger/logger.js').addSource({
+import baseLogger from '../../../../logger/logger.js';
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "handleRejectSuggestion",
     params: ['suggestionId', 'rejectedById']

--- a/backend/src/features/suggestion/services/handle-start.js
+++ b/backend/src/features/suggestion/services/handle-start.js
@@ -1,7 +1,8 @@
-const { AppError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "handleStartSuggestionReviewProcess",
     params: ['suggestionId', 'startedBy', 'notes', 'message']

--- a/backend/src/features/suggestion/services/handle-suggestion.js
+++ b/backend/src/features/suggestion/services/handle-suggestion.js
@@ -1,12 +1,12 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
-const Curriculums = require('../../curriculum/models/curriculums.model.js')
-const kebabToCamel = require('../../../shared/utils/kebabToCamel')
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import Curriculums from '../../curriculum/models/curriculums.model.js';
+import kebabToCamel from '../../../shared/utils/kebabToCamel.js';
+import linkCommunityMemberToSuggestion from './link-user.js';
+import assignAssociateEditorToSuggestion from './assign-editor.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const linkCommunityMemberToSuggestion = require('./link-user')
-const assignAssociateEditorToSuggestion = require('./assign-editor')
-
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "handleNewSuggestion",
     params: ['userId', 'title', 'suggestion', 'discipline']

--- a/backend/src/features/suggestion/services/index.js
+++ b/backend/src/features/suggestion/services/index.js
@@ -1,19 +1,19 @@
-const linkCommunityMemberToSuggestion = require('./link-user');
-const assignAssociateEditorToSuggestion = require('./assign-editor');
-const handleRejectSuggestion = require('./handle-reject');
-const handleNewSuggestion = require('./handle-suggestion');
-const getSuggestionById = require('./get-one');
-const handleStartSuggestionReviewProcess = require('./handle-start');
-const assignReviewersToSuggestion = require('./assign-reviewers');
-const addNewDocumentationToSuggestion = require('./add-documentation');
-const associateEditorFinalized = require('./finalize');
-const handleEditorInChiefApproval = require('./handle-approval');
-const sendChangeRequestToAssociateEditor = require('./send-change');
-const handleDeferSuggestionToReviewer = require('./handle-deferral');
-const addRecommendationFromReviewer = require('./handle-recommendation');
-const handleFinalDiscussion = require('./handle-discussion');
-const updateVote = require('./update-vote');
-const finalizeImplementation = require('./finalize-implementation');
+import linkCommunityMemberToSuggestion from './link-user';
+import assignAssociateEditorToSuggestion from './assign-editor';
+import handleRejectSuggestion from './handle-reject';
+import handleNewSuggestion from './handle-suggestion';
+import getSuggestionById from './get-one';
+import handleStartSuggestionReviewProcess from './handle-start';
+import assignReviewersToSuggestion from './assign-reviewers';
+import addNewDocumentationToSuggestion from './add-documentation';
+import associateEditorFinalized from './finalize';
+import handleEditorInChiefApproval from './handle-approval';
+import sendChangeRequestToAssociateEditor from './send-change';
+import handleDeferSuggestionToReviewer from './handle-deferral';
+import addRecommendationFromReviewer from './handle-recommendation';
+import handleFinalDiscussion from './handle-discussion';
+import updateVote from './update-vote';
+import finalizeImplementation from './finalize-implementation';
 
 module.exports = {
     handleRejectSuggestion,

--- a/backend/src/features/suggestion/services/link-user.js
+++ b/backend/src/features/suggestion/services/link-user.js
@@ -1,7 +1,8 @@
-const { AppError, NoUserWithIdError } = require('../../../shared/errors');
-const CommunityMembers = require('../../users/models/users/community-member/members.model');
+import { AppError, NoUserWithIdError } from '../../../shared/errors';
+import CommunityMembers from '../../users/models/users/community-member/members.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'auth.service',
     method: "linkCommunityMemberToSuggestion",
     params: ['userId', 'suggestionId']

--- a/backend/src/features/suggestion/services/send-change.js
+++ b/backend/src/features/suggestion/services/send-change.js
@@ -1,8 +1,8 @@
-const { AppError, SuggestionNotFoundError, NoUserWithIdError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
+import { AppError, SuggestionNotFoundError, NoUserWithIdError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import baseLogger from '../../../../logger/logger.js';
 
-
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "sendChangeRequestToAssociateEditor",
     params: ['suggestionId', 'author', 'markdownText']

--- a/backend/src/features/suggestion/services/update-vote.js
+++ b/backend/src/features/suggestion/services/update-vote.js
@@ -1,8 +1,9 @@
-const { AppError, SuggestionNotFoundError } = require('../../../shared/errors');
-const Suggestions = require('../models/suggestions.model.js')
-const { updateCurriculumSection } = require('../../curriculum/services');
+import { AppError, SuggestionNotFoundError } from '../../../shared/errors';
+import Suggestions from '../models/suggestions.model.js';
+import { updateCurriculumSection } from '../../curriculum/services';
+import baseLogger from '../../../../logger/logger.js';
 
-const logger = require('../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'suggestion.service',
     method: "updateVote",
     params: ['suggestionId', 'author', 'markdownText']

--- a/backend/src/features/users/controllers/users/associate-editor/get-final.js
+++ b/backend/src/features/users/controllers/users/associate-editor/get-final.js
@@ -1,7 +1,8 @@
-const getFinalAssociateEditorAssignedSuggestions = require('../../../services/users/associate-editor/get-final')
-const { AppError } = require('../../../../../shared/errors');
+import getFinalAssociateEditorAssignedSuggestions from '../../../services/users/associate-editor/get-final';
+import { AppError } from '../../../../../shared/errors';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.controller',
     method: "getSuggestions",
     params: ["req.params"]

--- a/backend/src/features/users/controllers/users/associate-editor/get-reviewers.js
+++ b/backend/src/features/users/controllers/users/associate-editor/get-reviewers.js
@@ -1,7 +1,8 @@
-const getAssignedReviewers = require('../../../services/users/associate-editor/get-reviewers')
-const { AppError } = require('../../../../../shared/errors');
+import getAssignedReviewers from '../../../services/users/associate-editor/get-reviewers';
+import { AppError } from '../../../../../shared/errors';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'associate-editor.controller.js',
     method: 'getReviewers',
     params: ['userId']

--- a/backend/src/features/users/controllers/users/associate-editor/get-suggestions.js
+++ b/backend/src/features/users/controllers/users/associate-editor/get-suggestions.js
@@ -1,7 +1,8 @@
-const getAssociateEditorAssignedSuggestions = require('../../../services/users/associate-editor/get-suggestions')
-const { AppError } = require('../../../../../shared/errors');
+import getAssociateEditorAssignedSuggestions from '../../../services/users/associate-editor/get-suggestions';
+import { AppError } from '../../../../../shared/errors';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.controller',
     method: "getSuggestions",
     params: ["req.params"]

--- a/backend/src/features/users/controllers/users/associate-editor/index.js
+++ b/backend/src/features/users/controllers/users/associate-editor/index.js
@@ -1,5 +1,5 @@
-const getSuggestions = require('./get-suggestions')
-const getReviewers = require('./get-reviewers')
-const getFinalSuggestions = require('./get-final')
+import getSuggestions from './get-suggestions';
+import getReviewers from './get-reviewers';
+import getFinalSuggestions from './get-final';
 
 module.exports = { getSuggestions, getReviewers, getFinalSuggestions }

--- a/backend/src/features/users/controllers/users/community-member/get-suggestions.js
+++ b/backend/src/features/users/controllers/users/community-member/get-suggestions.js
@@ -1,7 +1,8 @@
-const getAllCommunityMemberSuggestions = require('../../../services/users/community-member/get-suggestions')
-const { AppError } = require('../../../../../shared/errors');
+import getAllCommunityMemberSuggestions from '../../../services/users/community-member/get-suggestions';
+import { AppError } from '../../../../../shared/errors';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.controller',
     method: "getSuggestions",
     params: ["req.params"]

--- a/backend/src/features/users/controllers/users/community-member/index.js
+++ b/backend/src/features/users/controllers/users/community-member/index.js
@@ -1,3 +1,3 @@
-const getSuggestions = require('./get-suggestions')
+import getSuggestions from './get-suggestions';
 
-module.exports = {getSuggestions}
+module.exports = { getSuggestions };

--- a/backend/src/features/users/controllers/users/editor-in-chief/get-suggestions.js
+++ b/backend/src/features/users/controllers/users/editor-in-chief/get-suggestions.js
@@ -1,7 +1,8 @@
-const getFinalizedSuggestions = require('../../../services/users/editor-in-chief/get-finalized')
-const { AppError } = require('../../../../../shared/errors');
+import getFinalizedSuggestions from '../../../services/users/editor-in-chief/get-finalized';
+import { AppError } from '../../../../../shared/errors';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'reviewer',
     method: "getSuggestions",
     params: ["req.params"]

--- a/backend/src/features/users/controllers/users/editor-in-chief/index.js
+++ b/backend/src/features/users/controllers/users/editor-in-chief/index.js
@@ -1,3 +1,3 @@
-const getSuggestions = require('./get-suggestions')
+import getSuggestions from './get-suggestions';
 
-module.exports = {getSuggestions}
+module.exports = { getSuggestions };

--- a/backend/src/features/users/controllers/users/reviewer/get-suggestions.js
+++ b/backend/src/features/users/controllers/users/reviewer/get-suggestions.js
@@ -1,7 +1,8 @@
-const getReviewerAssignedSuggestions = require('../../../services/users/reviewer/get-suggestions')
-const { AppError } = require('../../../../../shared/errors');
+import getReviewerAssignedSuggestions from '../../../services/users/reviewer/get-suggestions';
+import { AppError } from '../../../../../shared/errors';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'reviewer',
     method: "getSuggestions",
     params: ["req.params"]

--- a/backend/src/features/users/controllers/users/reviewer/index.js
+++ b/backend/src/features/users/controllers/users/reviewer/index.js
@@ -1,3 +1,3 @@
-const getSuggestions = require('./get-suggestions')
+import getSuggestions from './get-suggestions';
 
-module.exports = {getSuggestions}
+module.exports = { getSuggestions };

--- a/backend/src/features/users/controllers/users/reviewer/self-nominate.js
+++ b/backend/src/features/users/controllers/users/reviewer/self-nominate.js
@@ -2,7 +2,7 @@
  * Reviewer self-nomination controller
  * @module controllers/users/reviewer/self-nominate
  */
-const path = require('path');
+import path from 'path';
 const Reviewer = require(path.join(__dirname, '../../../models/users/reviewer/reviewer.model.js'));
 const usersDb = require(path.join(__dirname, '../../../database/data/users/reviewer.json'));
 

--- a/backend/src/features/users/models/users/admin/admin.model.js
+++ b/backend/src/features/users/models/users/admin/admin.model.js
@@ -1,5 +1,5 @@
-const User = require('../user.model');
-const { Roles } = require('../../../../../../../docs/constants/roles.js');
+import User from '../user.model';
+import {  Roles  } from '../../../../../../../docs/constants/roles.js';
 
 class Admin extends User {
     static role = Roles.ADMIN;

--- a/backend/src/features/users/models/users/admin/admins.model.js
+++ b/backend/src/features/users/models/users/admin/admins.model.js
@@ -1,5 +1,5 @@
-const Users = require('../users.model.js');
-const Admin = require('./admin.model.js');
+import Users from '../users.model.js';
+import Admin from './admin.model.js';
 
 class Admins extends Users {
     static Model = Admin;

--- a/backend/src/features/users/models/users/associate-editor/editor.model.js
+++ b/backend/src/features/users/models/users/associate-editor/editor.model.js
@@ -1,5 +1,5 @@
 
-const User = require('../user.model');
+import User from '../user.model';
 
 
 class AssociateEditor extends User {

--- a/backend/src/features/users/models/users/associate-editor/editors.model.js
+++ b/backend/src/features/users/models/users/associate-editor/editors.model.js
@@ -1,6 +1,6 @@
 // models/CommunityMembers.js
-const Users = require('../users.model');
-const AssociateEditor = require('./editor.model');
+import Users from '../users.model';
+import AssociateEditor from './editor.model';
 
 class AssociateEditors extends Users {
     static roleKey = 'associateEditors';

--- a/backend/src/features/users/models/users/community-member/member.model.js
+++ b/backend/src/features/users/models/users/community-member/member.model.js
@@ -1,6 +1,6 @@
 // models/CommunityMember.js
-const User = require('../user.model');
-const { Roles } = require('../../../../../shared/constants');
+import User from '../user.model';
+import {  Roles  } from '../../../../../shared/constants';
 
 class CommunityMember extends User {
     static role = Roles.COMMUNITY_MEMBER;

--- a/backend/src/features/users/models/users/community-member/members.model.js
+++ b/backend/src/features/users/models/users/community-member/members.model.js
@@ -1,5 +1,5 @@
-const Users = require('../users.model.js');
-const CommunityMember = require('./member.model.js');
+import Users from '../users.model.js';
+import CommunityMember from './member.model.js';
 
 
 class CommunityMembers extends Users {

--- a/backend/src/features/users/models/users/editor-in-chief/chief.model.js
+++ b/backend/src/features/users/models/users/editor-in-chief/chief.model.js
@@ -1,6 +1,6 @@
 // models/CommunityMember.js
-const User = require('../user.model');
-const { Roles } = require('../../../../../../../docs/constants/roles.js');
+import User from '../user.model';
+import {  Roles  } from '../../../../../../../docs/constants/roles.js';
 
 
 class EditorInChief extends User {

--- a/backend/src/features/users/models/users/editor-in-chief/chiefs.model.js
+++ b/backend/src/features/users/models/users/editor-in-chief/chiefs.model.js
@@ -1,5 +1,5 @@
-const Users = require('../users.model.js');
-const EditorInChief = require('./chief.model.js');
+import Users from '../users.model.js';
+import EditorInChief from './chief.model.js';
 
 
 class EditorsInChief extends Users {

--- a/backend/src/features/users/models/users/reviewer/reviewer.model.js
+++ b/backend/src/features/users/models/users/reviewer/reviewer.model.js
@@ -1,6 +1,6 @@
 // models/CommunityMember.js
-const User = require('../user.model');
-const { Roles } = require('../../../../../../../docs/constants/roles.js');
+import User from '../user.model';
+import {  Roles  } from '../../../../../../../docs/constants/roles.js';
 
 
 class Reviewer extends User {

--- a/backend/src/features/users/models/users/reviewer/reviewers.model.js
+++ b/backend/src/features/users/models/users/reviewer/reviewers.model.js
@@ -1,5 +1,5 @@
-const Users = require('../users.model.js');
-const Reviewer = require('./reviewer.model.js');
+import Users from '../users.model.js';
+import Reviewer from './reviewer.model.js';
 
 
 class Reviewers extends Users {

--- a/backend/src/features/users/models/users/user.model.js
+++ b/backend/src/features/users/models/users/user.model.js
@@ -1,4 +1,4 @@
-const { generateUserId } = require('../../../../shared/utils/generate-id');
+import {  generateUserId  } from '../../../../shared/utils/generate-id';
 
 
 class User {

--- a/backend/src/features/users/models/users/users.model.js
+++ b/backend/src/features/users/models/users/users.model.js
@@ -1,4 +1,9 @@
 // models/Users.js
+import CommunityMembers from './community-member/members.model.js';
+import AssociateEditors from './associate-editor/editors.model.js';
+import Reviewers from './reviewer/reviewers.model.js';
+import ChiefEditors from './editor-in-chief/chiefs.model.js';
+import Admins from './admin/admins.model.js';
 
 class Users {
     static dbRef;
@@ -18,11 +23,11 @@ class Users {
      */
     static getRegistry() {
         return {
-            communityMembers: require('./community-member/members.model'),
-            associateEditors: require('./associate-editor/editors.model'),
-            reviewers: require('./reviewer/reviewers.model'),
-            chiefEditors: require('./editor-in-chief/chiefs.model'),
-            admins: require('./admin/admins.model')
+            communityMembers: CommunityMembers,
+            associateEditors: AssociateEditors,
+            reviewers: Reviewers,
+            chiefEditors: ChiefEditors,
+            admins: Admins
             // reviewers: ...
         };
     }

--- a/backend/src/features/users/routes.js
+++ b/backend/src/features/users/routes.js
@@ -1,11 +1,14 @@
-const express = require('express');
+import express from 'express';
+import communityMemberRouter from './routes/community-member.routes.js';
+import reviewerRouter from './routes/reviewer.routes.js';
+import associateEditorRouter from './routes/associate-editor.routes.js';
+import editorInChiefRouter from './routes/editor-in-chief.routes.js';
+
 const router = express.Router();
 
-
-
-router.use('/community-member', require('./routes/community-member.routes.js'));
-router.use('/reviewer', require('./routes/reviewer.routes.js'));
-router.use('/associate-editor', require('./routes/associate-editor.routes.js'));
-router.use('/editor-in-chief', require('./routes/editor-in-chief.routes.js'));
+router.use('/community-member', communityMemberRouter);
+router.use('/reviewer', reviewerRouter);
+router.use('/associate-editor', associateEditorRouter);
+router.use('/editor-in-chief', editorInChiefRouter);
 
 module.exports = router;

--- a/backend/src/features/users/routes/associate-editor.routes.js
+++ b/backend/src/features/users/routes/associate-editor.routes.js
@@ -1,6 +1,6 @@
-const express = require('express');
+import express from 'express';
 
-const { getSuggestions, getReviewers, getFinalSuggestions } = require('../controllers/users/associate-editor');
+import {  getSuggestions, getReviewers, getFinalSuggestions  } from '../controllers/users/associate-editor';
 
 const router = express.Router();
 

--- a/backend/src/features/users/routes/community-member.routes.js
+++ b/backend/src/features/users/routes/community-member.routes.js
@@ -1,6 +1,6 @@
-const express = require('express');
+import express from 'express';
 
-const { getSuggestions } = require('../controllers/users/community-member');
+import {  getSuggestions  } from '../controllers/users/community-member';
 
 const router = express.Router();
 

--- a/backend/src/features/users/routes/editor-in-chief.routes.js
+++ b/backend/src/features/users/routes/editor-in-chief.routes.js
@@ -1,6 +1,6 @@
-const express = require('express');
+import express from 'express';
 
-const { getSuggestions } = require('../controllers/users/editor-in-chief');
+import {  getSuggestions  } from '../controllers/users/editor-in-chief';
 
 const router = express.Router();
 

--- a/backend/src/features/users/routes/reviewer.routes.js
+++ b/backend/src/features/users/routes/reviewer.routes.js
@@ -1,6 +1,6 @@
-const express = require('express');
+import express from 'express';
 
-const { getSuggestions } = require('../controllers/users/reviewer');
+import {  getSuggestions  } from '../controllers/users/reviewer';
 
 const router = express.Router();
 

--- a/backend/src/features/users/services/users/associate-editor/get-final.js
+++ b/backend/src/features/users/services/users/associate-editor/get-final.js
@@ -1,8 +1,9 @@
 
-const { AppError } = require('../../../../../shared/errors');
-const Suggestions = require('../../../../suggestion/models/suggestions.model.js')
+import { AppError } from '../../../../../shared/errors';
+import Suggestions from '../../../../suggestion/models/suggestions.model.js';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.service',
     method: "getFinalAssociateEditorAssignedSuggestions",
     params: ['userId']

--- a/backend/src/features/users/services/users/associate-editor/get-reviewers.js
+++ b/backend/src/features/users/services/users/associate-editor/get-reviewers.js
@@ -1,6 +1,8 @@
-const { AppError } = require('../../../../../shared/errors');
-const Reviewers = require('../../../models/users/reviewer/reviewers.model.js')
-const logger = require('../../../../../../logger/logger.js').addSource({
+import { AppError } from '../../../../../shared/errors';
+import Reviewers from '../../../models/users/reviewer/reviewers.model.js';
+import baseLogger from '../../../../../../logger/logger.js';
+
+const logger = baseLogger.addSource({
     file: 'associate-editor.service',
     method: "getAssignedReviewers",
     params: ['userId']

--- a/backend/src/features/users/services/users/associate-editor/get-suggestions.js
+++ b/backend/src/features/users/services/users/associate-editor/get-suggestions.js
@@ -1,7 +1,8 @@
-const { AppError } = require('../../../../../shared/errors');
-const Suggestions = require('../../../../suggestion/models/suggestions.model.js')
+import { AppError } from '../../../../../shared/errors';
+import Suggestions from '../../../../suggestion/models/suggestions.model.js';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.service',
     method: "getAllCommunityMemberSuggestions",
     params: ['userId']

--- a/backend/src/features/users/services/users/community-member/get-suggestions.js
+++ b/backend/src/features/users/services/users/community-member/get-suggestions.js
@@ -1,8 +1,9 @@
-const { AppError } = require('../../../../../shared/errors');
-const Suggestions = require('../../../../suggestion/models/suggestions.model.js')
-const { getUserNameById } = require('../../../../../shared/utils/getUserNameById')
+import { AppError } from '../../../../../shared/errors';
+import Suggestions from '../../../../suggestion/models/suggestions.model.js';
+import { getUserNameById } from '../../../../../shared/utils/getUserNameById';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.service',
     method: "getAllCommunityMemberSuggestions",
     params: ['userId']

--- a/backend/src/features/users/services/users/editor-in-chief/get-finalized.js
+++ b/backend/src/features/users/services/users/editor-in-chief/get-finalized.js
@@ -1,7 +1,8 @@
-const { AppError } = require('../../../../../shared/errors');
-const Suggestions = require('../../../../suggestion/models/suggestions.model.js')
+import { AppError } from '../../../../../shared/errors';
+import Suggestions from '../../../../suggestion/models/suggestions.model.js';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'community-member.service',
     method: "getAllCommunityMemberSuggestions",
     params: ['userId']

--- a/backend/src/features/users/services/users/reviewer/get-suggestions.js
+++ b/backend/src/features/users/services/users/reviewer/get-suggestions.js
@@ -1,6 +1,7 @@
-const Suggestions = require('../../../../suggestion/models/suggestions.model.js')
+import Suggestions from '../../../../suggestion/models/suggestions.model.js';
+import baseLogger from '../../../../../../logger/logger.js';
 
-const logger = require('../../../../../../logger/logger.js').addSource({
+const logger = baseLogger.addSource({
     file: 'reviewer.service',
     method: "getReviewerAssignedSuggestions",
     params: ['userId']

--- a/backend/src/shared/constants/index.js
+++ b/backend/src/shared/constants/index.js
@@ -1,6 +1,6 @@
-const HTTP_STATUS = require('./http-codes');
-const { Roles } = require('../../../../docs/constants/roles.js');
-const { Status } = require('../../../../docs/constants/status.js');
+import HTTP_STATUS from './http-codes';
+import {  Roles  } from '../../../../docs/constants/roles.js';
+import {  Status  } from '../../../../docs/constants/status.js';
 
 const Actions = Object.freeze({
     DESK_REJECT: 'desk-reject',

--- a/backend/src/shared/errors/index.js
+++ b/backend/src/shared/errors/index.js
@@ -1,4 +1,4 @@
-const HTTP_STATUS = require('../constants/http-codes.js');
+import HTTP_STATUS from '../constants/http-codes.js';
 
 
 class AppError extends Error {

--- a/backend/src/shared/utils/generate-id.js
+++ b/backend/src/shared/utils/generate-id.js
@@ -1,4 +1,4 @@
-const { nanoid } = require('nanoid');
+import {  nanoid  } from 'nanoid';
 // const { Status } = require('../../../../docs/constants/status.js');
 
 

--- a/backend/src/socket.js
+++ b/backend/src/socket.js
@@ -1,9 +1,11 @@
-const { Server } = require('socket.io');
-const logger = require('../logger/logger.js').addSource({
+import { Server } from 'socket.io';
+import baseLogger from '../logger/logger.js';
+import { updateVote } from './features/suggestion/services';
+
+const logger = baseLogger.addSource({
     file: 'socket.js',
     method: 'socket',
 });
-const { updateVote } = require('./features/suggestion/services')
 /**
  * Set up Socket.IO server on the existing HTTP server.
  */


### PR DESCRIPTION
## Summary
- update backend codebase to use ES module `import` syntax
- replace `require()` calls throughout backend services, controllers, and models

## Testing
- `npm run docs` *(fails: jsdoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_688803c0fad4832d86f24603be9f9cfb