### PR TITLE
Refactor database init

### DIFF
--- a/backend/src/database/database.js
+++ b/backend/src/database/database.js
@@ -36,91 +36,80 @@ async function createDB(targetPath, defaultJsonPath, { forceReset = false } = {}
 
 async function createDatabases(options = {}) {
   const reset = options.forceReset || false;
+
+  const userSpecs = [
+    ['communityMembers', 'community_member'],
+    ['reviewers', 'reviewer'],
+    ['associateEditors', 'associate_editor'],
+    ['chiefEditors', 'editor_in_chief'],
+    ['admins', 'admin'],
+  ];
+
+  const userEntries = await Promise.all(
+    userSpecs.map(async ([key, file]) => [
+      key,
+      await createDB(
+        `data/users/${file}.json`,
+        `data/users/default/${file}.json`,
+        { forceReset: reset }
+      ),
+    ])
+  );
+
+  const users = Object.fromEntries(userEntries);
+
+  const curriculumSpecs = [
+    ['computerScience', 'computer-science'],
+    ['cybersecurity', 'cybersecurity'],
+  ];
+
+  const curriculumEntries = await Promise.all(
+    curriculumSpecs.map(async ([key, dir]) => {
+      const [tableOfContents, pageContent, curriculumVersions] = await Promise.all([
+        createDB(
+          `data/curriculums/${dir}/table_of_contents.json`,
+          `data/curriculums/${dir}/default/table_of_contents.json`,
+          { forceReset: reset }
+        ),
+        createDB(
+          `data/curriculums/${dir}/page_content.json`,
+          `data/curriculums/${dir}/default/page_content.json`,
+          { forceReset: reset }
+        ),
+        createDB(
+          `data/curriculums/${dir}/versions.json`,
+          `data/curriculums/${dir}/default/versions.json`,
+          { forceReset: reset }
+        ),
+      ]);
+
+      return [key, { tableOfContents, pageContent, curriculumVersions }];
+    })
+  );
+
+  const curriculums = Object.fromEntries(curriculumEntries);
+
+  const suggestions = await createDB(
+    'data/suggestions/suggestions.json',
+    'data/suggestions/default/suggestions.json',
+    { forceReset: reset }
+  );
+
   const db = {
-    users: {
-      communityMembers: await createDB(
-        'data/users/community_member.json',
-        'data/users/default/community_member.json',
-        { forceReset: reset }
-      ),
-      reviewers: await createDB(
-        'data/users/reviewer.json',
-        'data/users/default/reviewer.json',
-        { forceReset: reset }
-      ),
-      associateEditors: await createDB(
-        'data/users/associate_editor.json',
-        'data/users/default/associate_editor.json',
-        { forceReset: reset }
-      ),
-      chiefEditors: await createDB(
-        'data/users/editor_in_chief.json',
-        'data/users/default/editor_in_chief.json',
-        { forceReset: reset }
-      ),
-      admins: await createDB(
-        'data/users/admin.json',
-        'data/users/default/admin.json',
-        { forceReset: reset }
-      ),
-    },
-    suggestions: await createDB(
-      'data/suggestions/suggestions.json',
-      'data/suggestions/default/suggestions.json',
-      { forceReset: reset }
-    ),
-    curriculums: {
-      computerScience: {
-        tableOfContents: await createDB(
-          'data/curriculums/computer-science/table_of_contents.json',
-          'data/curriculums/computer-science/default/table_of_contents.json',
-          { forceReset: reset }
-        ),
-        pageContent: await createDB(
-          'data/curriculums/computer-science/page_content.json',
-          'data/curriculums/computer-science/default/page_content.json',
-          { forceReset: reset }
-        ),
-        curriculumVersions: await createDB(
-          'data/curriculums/computer-science/versions.json',
-          'data/curriculums/computer-science/default/versions.json',
-          { forceReset: reset }
-        ),
-      },
-      cybersecurity: {
-        tableOfContents: await createDB(
-          'data/curriculums/cybersecurity/table_of_contents.json',
-          'data/curriculums/cybersecurity/default/table_of_contents.json',
-          { forceReset: reset }
-        ),
-        pageContent: await createDB(
-          'data/curriculums/cybersecurity/page_content.json',
-          'data/curriculums/cybersecurity/default/page_content.json',
-          { forceReset: reset }
-        ),
-        curriculumVersions: await createDB(
-          'data/curriculums/cybersecurity/versions.json',
-          'data/curriculums/cybersecurity/default/versions.json',
-          { forceReset: reset }
-        ),
-      },
-    },
+    users,
+    suggestions,
+    curriculums,
   };
 
   async function resetAll() {
     await Promise.all([
-      db.users.communityMembers.reset(),
-      db.users.reviewers.reset(),
-      db.users.associateEditors.reset(),
-      db.users.chiefEditors.reset(),
-      db.users.admins.reset(),
+      ...Object.values(db.users).map((u) => u.reset()),
       db.suggestions.reset(),
-      db.curriculums.computerScience.tableOfContents.reset(),
-      db.curriculums.computerScience.pageContent.reset(),
-      db.curriculums.computerScience.curriculumVersions.reset(),
-      db.curriculums.cybersecurity.tableOfContents.reset(),
-      db.curriculums.cybersecurity.pageContent.reset(),
-      db.curriculums.cybersecurity.curriculumVersions.reset(),
+      ...Object.values(db.curriculums).flatMap((c) => [
+        c.tableOfContents.reset(),
+        c.pageContent.reset(),
+        c.curriculumVersions.reset(),
+      ]),
     ]);
   }
 


### PR DESCRIPTION
## Summary
- DRY up `createDatabases` by defining specs for user and curriculum DBs
- use `Promise.all` and `Object.fromEntries` to build objects
- simplify reset logic using loops

## Testing
- `node -e "import('./backend/src/database/database.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_688815190798832d8ea889c8e38bceb8