### PR TITLE
Refactor DB init for static usage

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,15 +1,7 @@
 import http from 'http';
 import morgan from 'morgan';
-import { app, injectDB as injectAppDB } from './src/app.js';
-import { createDatabases } from './src/database/database.js';
-import Suggestions from './src/features/suggestion/models/suggestions.model.js';
-import Curriculums from './src/features/curriculum/models/curriculums.model.js';
-import Curriculum from './src/features/curriculum/models/curriculum.model.js';
-import CurriculumVersions from './src/features/curriculum/models/versions.model.js';
-import Users from './src/features/users/models/users/users.model.js';
-import finalizeImplementationService from './src/features/suggestion/services/finalize-implementation.js';
-import userInfoUtil from './src/shared/utils/getUserInfoById.js';
-import userNameUtil from './src/shared/utils/getUserNameById.js';
+import { app } from './src/app.js';
+import db from './src/database/database.js';
 import { setupSocketIO } from './src/socket.js';
 import baseLogger from './logger/logger.js';
 
@@ -17,30 +9,17 @@ const logger = baseLogger.addSource({ file: 'server.js', method: 'listen' });
 
 const PORT = process.env.PORT || 3000;
 
-(async () => {
-    const db = await createDatabases();
-    injectAppDB(db);
-    Suggestions.injectDB(db.suggestions);
-    Curriculums.injectDB(db.curriculums);
-    Curriculum.injectDB(db.curriculums);
-    CurriculumVersions.injectDB(db.curriculums);
-    Users.injectDB(db.users);
-    finalizeImplementationService.injectDB(db);
-    userInfoUtil.injectDB(db);
-    userNameUtil.injectDB(db);
+const server = http.createServer(app); // <-- needed for socket.io
+setupSocketIO(server); // see below
 
-    const server = http.createServer(app); // <-- needed for socket.io
-    setupSocketIO(server); // see below
+server.listen(PORT, () => {
+    logger.info('app.started', { PORT });
+});
 
-    server.listen(PORT, () => {
-        logger.info('app.started', { PORT });
-    });
-
-    app.use(
-        morgan('combined', {
-            stream: {
-                write: (msg) => logger.debug(msg.trim()),
-            },
-        })
-    );
-})();
+app.use(
+    morgan('combined', {
+        stream: {
+            write: (msg) => logger.debug(msg.trim()),
+        },
+    })
+);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,10 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-let db;
-
-function injectDB(instance) {
-    db = instance;
-}
+import db from './database/database.js';
 import authRoutes from './features/auth/routes.js';
 import suggestionRoutes from './features/suggestion/routes.js';
 import userRoutes from './features/users/routes.js';
@@ -55,4 +51,4 @@ app.use((err, req, res, next) => {
 
 
 
-export { app, injectDB };
+export { app };

--- a/backend/src/database/database.js
+++ b/backend/src/database/database.js
@@ -1,123 +1,132 @@
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { Low } from 'lowdb';
+import { JSONFile } from 'lowdb/node';
+import { createRequire } from 'module';
 
+const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
 const resolve = (...segments) => path.resolve(__dirname, ...segments);
 
-async function createDB(targetPath, defaultJsonPath, { forceReset = false } = {}) {
-  const { Low } = await import('lowdb');
-  const { JSONFile } = await import('lowdb/node');
+function createDB(targetPath, defaultJsonPath, { forceReset = false } = {}) {
+    const filePath = resolve(targetPath);
+    const defaultData = require(resolve(defaultJsonPath));
+    const adapter = new JSONFile(filePath);
+    const db = new Low(adapter, defaultData);
 
-  const filePath = resolve(targetPath);
-  const defaultDataModule = await import(
-    resolve(defaultJsonPath),
-    { assert: { type: 'json' } }
-  );
-  const defaultData = defaultDataModule.default;
-  const adapter = new JSONFile(filePath);
-  const db = new Low(adapter, defaultData);
-  try {
-    await db.read();
-    if (forceReset || !db.data) {
-      db.data = defaultData;
-      await db.write();
-    }
-  } catch (err) {
-    console.warn(`⚠️ Failed to load ${filePath}, reinitializing with defaults.`);
-    db.data = defaultData;
-    await db.write();
-  }
+    (async () => {
+        try {
+            await db.read();
+            if (forceReset || !db.data) {
+                db.data = defaultData;
+                await db.write();
+            }
+        } catch (err) {
+            console.warn(`⚠️ Failed to load ${filePath}, reinitializing with defaults.`);
+            db.data = defaultData;
+            await db.write();
+        }
+    })();
 
-  db.reset = async () => {
-    db.data = defaultData;
-    await db.write();
-  };
+    db.reset = async () => {
+        db.data = defaultData;
+        await db.write();
+    };
 
-  return db;
+    return db;
 }
 
-async function createDatabases(options = {}) {
-  const reset = options.forceReset || false;
+const reset = false;
 
-  const userSpecs = [
-    ['communityMembers', 'community_member'],
-    ['reviewers', 'reviewer'],
-    ['associateEditors', 'associate_editor'],
-    ['chiefEditors', 'editor_in_chief'],
-    ['admins', 'admin'],
-  ];
-
-  const userEntries = await Promise.all(
-    userSpecs.map(async ([key, file]) => [
-      key,
-      await createDB(
-        `data/users/${file}.json`,
-        `data/users/default/${file}.json`,
+const db = {
+    users: {
+        communityMembers: createDB(
+            'data/users/community_member.json',
+            'data/users/default/community_member.json',
+            { forceReset: reset }
+        ),
+        reviewers: createDB(
+            'data/users/reviewer.json',
+            'data/users/default/reviewer.json',
+            { forceReset: reset }
+        ),
+        associateEditors: createDB(
+            'data/users/associate_editor.json',
+            'data/users/default/associate_editor.json',
+            { forceReset: reset }
+        ),
+        chiefEditors: createDB(
+            'data/users/editor_in_chief.json',
+            'data/users/default/editor_in_chief.json',
+            { forceReset: reset }
+        ),
+        admins: createDB(
+            'data/users/admin.json',
+            'data/users/default/admin.json',
+            { forceReset: reset }
+        ),
+    },
+    suggestions: createDB(
+        'data/suggestions/suggestions.json',
+        'data/suggestions/default/suggestions.json',
         { forceReset: reset }
-      ),
-    ])
-  );
+    ),
+    curriculums: {
+        computerScience: {
+            tableOfContents: createDB(
+                'data/curriculums/computer-science/table_of_contents.json',
+                'data/curriculums/computer-science/default/table_of_contents.json',
+                { forceReset: reset }
+            ),
+            pageContent: createDB(
+                'data/curriculums/computer-science/page_content.json',
+                'data/curriculums/computer-science/default/page_content.json',
+                { forceReset: reset }
+            ),
+            curriculumVersions: createDB(
+                'data/curriculums/computer-science/versions.json',
+                'data/curriculums/computer-science/default/versions.json',
+                { forceReset: reset }
+            )
+        },
+        cybersecurity: {
+            tableOfContents: createDB(
+                'data/curriculums/cybersecurity/table_of_contents.json',
+                'data/curriculums/cybersecurity/default/table_of_contents.json',
+                { forceReset: reset }
+            ),
+            pageContent: createDB(
+                'data/curriculums/cybersecurity/page_content.json',
+                'data/curriculums/cybersecurity/default/page_content.json',
+                { forceReset: reset }
+            ),
+            curriculumVersions: createDB(
+                'data/curriculums/cybersecurity/versions.json',
+                'data/curriculums/cybersecurity/default/versions.json',
+                { forceReset: reset }
+            )
+        },
+    }
+};
 
-  const users = Object.fromEntries(userEntries);
-
-  const curriculumSpecs = [
-    ['computerScience', 'computer-science'],
-    ['cybersecurity', 'cybersecurity'],
-  ];
-
-  const curriculumEntries = await Promise.all(
-    curriculumSpecs.map(async ([key, dir]) => {
-      const [tableOfContents, pageContent, curriculumVersions] = await Promise.all([
-        createDB(
-          `data/curriculums/${dir}/table_of_contents.json`,
-          `data/curriculums/${dir}/default/table_of_contents.json`,
-          { forceReset: reset }
-        ),
-        createDB(
-          `data/curriculums/${dir}/page_content.json`,
-          `data/curriculums/${dir}/default/page_content.json`,
-          { forceReset: reset }
-        ),
-        createDB(
-          `data/curriculums/${dir}/versions.json`,
-          `data/curriculums/${dir}/default/versions.json`,
-          { forceReset: reset }
-        ),
-      ]);
-
-      return [key, { tableOfContents, pageContent, curriculumVersions }];
-    })
-  );
-
-  const curriculums = Object.fromEntries(curriculumEntries);
-
-  const suggestions = await createDB(
-    'data/suggestions/suggestions.json',
-    'data/suggestions/default/suggestions.json',
-    { forceReset: reset }
-  );
-
-  const db = {
-    users,
-    suggestions,
-    curriculums,
-  };
-
-  async function resetAll() {
+async function resetAll() {
     await Promise.all([
-      ...Object.values(db.users).map((u) => u.reset()),
-      db.suggestions.reset(),
-      ...Object.values(db.curriculums).flatMap((c) => [
-        c.tableOfContents.reset(),
-        c.pageContent.reset(),
-        c.curriculumVersions.reset(),
-      ]),
+        db.users.communityMembers.reset(),
+        db.users.reviewers.reset(),
+        db.users.associateEditors.reset(),
+        db.users.chiefEditors.reset(),
+        db.users.admins.reset(),
+        db.suggestions.reset(),
+        db.curriculums.computerScience.tableOfContents.reset(),
+        db.curriculums.computerScience.pageContent.reset(),
+        db.curriculums.computerScience.curriculumVersions.reset(),
+        db.curriculums.cybersecurity.tableOfContents.reset(),
+        db.curriculums.cybersecurity.pageContent.reset(),
+        db.curriculums.cybersecurity.curriculumVersions.reset(),
     ]);
-  }
-
-  db.resetAll = resetAll;
-  return db;
 }
 
-export { createDB, createDatabases };
+db.resetAll = resetAll;
+
+export { createDB };
+export default db;

--- a/backend/src/features/curriculum/models/curriculum.model.js
+++ b/backend/src/features/curriculum/models/curriculum.model.js
@@ -1,20 +1,18 @@
-class Curriculum {
-    static dbRef;
+import db from '../../../database/database.js';
 
-    static injectDB(dbInstance) {
-        this.dbRef = dbInstance;
-    }
+class Curriculum {
+    dbRef = db.curriculums;
 
     constructor(ref) {
         this.currRef = ref
 
     }
     async returnAll() {
-        await this.constructor.dbRef[this.currRef]?.tableOfContents.read();
-        const toc = this.constructor.dbRef[this.currRef]?.tableOfContents.data;
+        await this.dbRef[this.currRef]?.tableOfContents.read();
+        const toc = this.dbRef[this.currRef]?.tableOfContents.data;
 
-        await this.constructor.dbRef[this.currRef]?.pageContent.read();
-        const cont = this.constructor.dbRef[this.currRef]?.pageContent.data;
+        await this.dbRef[this.currRef]?.pageContent.read();
+        const cont = this.dbRef[this.currRef]?.pageContent.data;
 
         const contentMap = new Map(cont.map(entry => [entry.id, {
             content: entry.content,
@@ -45,10 +43,10 @@ class Curriculum {
 
 
     async getSection(id) {
-        await this.constructor.dbRef[this.currRef]?.tableOfContents.read();
-        const toc = this.constructor.dbRef[this.currRef]?.tableOfContents.data;
-        await this.constructor.dbRef[this.currRef]?.pageContent.read();
-        const cont = this.constructor.dbRef[this.currRef]?.pageContent.data;
+        await this.dbRef[this.currRef]?.tableOfContents.read();
+        const toc = this.dbRef[this.currRef]?.tableOfContents.data;
+        await this.dbRef[this.currRef]?.pageContent.read();
+        const cont = this.dbRef[this.currRef]?.pageContent.data;
 
         const contentMap = new Map(cont.map(entry => [entry.id, entry.content]));
         const section = toc.find(section => section.id === id);
@@ -81,8 +79,8 @@ class Curriculum {
 
 
     async getSectionToc(id) {
-        await this.constructor.dbRef[this.currRef]?.tableOfContents.read();
-        const toc = this.constructor.dbRef[this.currRef]?.tableOfContents.data;
+        await this.dbRef[this.currRef]?.tableOfContents.read();
+        const toc = this.dbRef[this.currRef]?.tableOfContents.data;
 
 
         const section = toc.find(section => section.id === id);
@@ -94,13 +92,13 @@ class Curriculum {
         return section
     }
     async updateToc(sectionInstance) {
-        await this.constructor.dbRef[this.currRef]?.tableOfContents.read();
+        await this.dbRef[this.currRef]?.tableOfContents.read();
 
-        const index = this.constructor.dbRef[this.currRef]?.tableOfContents.data.findIndex(s => s.id === sectionInstance.id);
+        const index = this.dbRef[this.currRef]?.tableOfContents.data.findIndex(s => s.id === sectionInstance.id);
         if (index === -1) throw new Error(`Suggestion with id ${sectionInstance.id} not found`);
 
-        this.constructor.dbRef[this.currRef].tableOfContents.data[index] = sectionInstance;
-        await this.constructor.dbRef[this.currRef]?.tableOfContents.write();
+        this.dbRef[this.currRef].tableOfContents.data[index] = sectionInstance;
+        await this.dbRef[this.currRef]?.tableOfContents.write();
 
         return sectionInstance;
     }
@@ -114,13 +112,13 @@ class Curriculum {
      * @throws {Error} If the suggestion with the specified ID does not exist.
      */
     async update(sectionInstance) {
-        await this.constructor.dbRef[this.currRef]?.pageContent.read();
+        await this.dbRef[this.currRef]?.pageContent.read();
 
-        const index = this.constructor.dbRef[this.currRef]?.pageContent.data.findIndex(s => s.id === sectionInstance.id);
+        const index = this.dbRef[this.currRef]?.pageContent.data.findIndex(s => s.id === sectionInstance.id);
         if (index === -1) throw new Error(`Suggestion with id ${sectionInstance.id} not found`);
 
-        this.constructor.dbRef[this.currRef].pageContent.data[index] = sectionInstance;
-        await this.constructor.dbRef[this.currRef]?.pageContent.write();
+        this.dbRef[this.currRef].pageContent.data[index] = sectionInstance;
+        await this.dbRef[this.currRef]?.pageContent.write();
 
         return sectionInstance;
     }

--- a/backend/src/features/curriculum/models/curriculums.model.js
+++ b/backend/src/features/curriculum/models/curriculums.model.js
@@ -1,14 +1,11 @@
-import {  flattenSections  } from '../../../../../docs/shared/utils/flatten.js';
+import { flattenSections } from '../../../../../docs/shared/utils/flatten.js';
 import Curriculum from "./curriculum.model.js";
+import db from '../../../database/database.js';
 
 
 
 class Curriculums {
-    static dbRef;
-
-    static injectDB(dbInstance) {
-        this.dbRef = dbInstance;
-    }
+    static dbRef = db.curriculums;
 
 
     /**

--- a/backend/src/features/curriculum/models/versions.model.js
+++ b/backend/src/features/curriculum/models/versions.model.js
@@ -1,11 +1,15 @@
 import CurriculumVersion from "./curriculum-version.model.js";
 import kebabToCamel from "../../../shared/utils/kebabToCamel.js";
-class CurriculumVersions {
-    static dbRef;
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import db from '../../../database/database.js';
 
-    static injectDB(dbInstance) {
-        this.dbRef = dbInstance;
-    }
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const resolve = (...segments) => path.resolve(__dirname, ...segments);
+class CurriculumVersions {
+    static dbRef = db.curriculums;
 
     static async getAll(curriculum) {
         await this.dbRef[curriculum].curriculumVersions.read();
@@ -38,11 +42,9 @@ class CurriculumVersions {
 
                 if (exists) {
             try {
-                const defaultsModule = await import(
-                    `../../../database/data/curriculums/${curriculum}/default/versions.json`,
-                    { assert: { type: 'json' } }
+                const defaults = require(
+                    resolve(`../../../database/data/curriculums/${curriculum}/default/versions.json`)
                 );
-                const defaults = defaultsModule.default;
                 found = defaults.find(v => v.id === id);
             } catch (err) {
                 found = null;

--- a/backend/src/features/suggestion/models/suggestions.model.js
+++ b/backend/src/features/suggestion/models/suggestions.model.js
@@ -1,13 +1,10 @@
 import Suggestion from "./suggestion.model.js";
-import {  Roles  } from '../../../../../docs/constants/roles.js';
-import {  Status  } from '../../../../../docs/constants/status.js';
+import { Roles } from '../../../../../docs/constants/roles.js';
+import { Status } from '../../../../../docs/constants/status.js';
+import db from '../../../database/database.js';
 
 class Suggestions {
-    static dbRef;
-
-    static injectDB(dbInstance) {
-        this.dbRef = dbInstance;
-    }
+    static dbRef = db.suggestions;
 
 
     /**

--- a/backend/src/features/suggestion/services/finalize-implementation.js
+++ b/backend/src/features/suggestion/services/finalize-implementation.js
@@ -5,11 +5,7 @@ import addCurriculumVersion from '../../curriculum/services/add-version.js';
 import { generateSectionId } from "../../../shared/utils/generate-id.js";
 import kebabToCamel from '../../../shared/utils/kebabToCamel.js';
 import baseLogger from '../../../../logger/logger.js';
-let db;
-
-function injectDB(instance) {
-    db = instance;
-}
+import db from '../../../database/database.js';
 
 const logger = baseLogger.addSource({
     file: 'suggestion.service',
@@ -102,4 +98,4 @@ const finalizeImplementation = async (id, eicId, notes, message) => {
     }
 };
 
-export { finalizeImplementation, injectDB };
+export { finalizeImplementation };

--- a/backend/src/features/users/models/users/users.model.js
+++ b/backend/src/features/users/models/users/users.model.js
@@ -4,13 +4,10 @@ import AssociateEditors from './associate-editor/editors.model.js';
 import Reviewers from './reviewer/reviewers.model.js';
 import ChiefEditors from './editor-in-chief/chiefs.model.js';
 import Admins from './admin/admins.model.js';
+import db from '../../../../database/database.js';
 
 class Users {
-    static dbRef;
-
-    static injectDB(dbInstance) {
-        this.dbRef = dbInstance;
-    }
+    static dbRef = db.users;
 
     static getDbRef() {
         const dbRef = this.dbRef[this.roleKey];

--- a/backend/src/shared/utils/getUserInfoById.js
+++ b/backend/src/shared/utils/getUserInfoById.js
@@ -1,8 +1,4 @@
-let db;
-
-function injectDB(instance) {
-    db = instance;
-}
+import db from '../../database/database.js';
 
 const roleMap = {
     CM: 'communityMembers',
@@ -24,6 +20,5 @@ async function getUserInfoById(id) {
 }
 
 export default {
-    getUserInfoById,
-    injectDB
+    getUserInfoById
 };

--- a/backend/src/shared/utils/getUserNameById.js
+++ b/backend/src/shared/utils/getUserNameById.js
@@ -1,8 +1,4 @@
-let db;
-
-function injectDB(instance) {
-    db = instance;
-}
+import db from '../../database/database.js';
 
 const roleMap = {
     CM: 'communityMembers',
@@ -24,6 +20,5 @@ async function getUserNameById(id) {
 }
 
 export default {
-    getUserNameById,
-    injectDB
+    getUserNameById
 };


### PR DESCRIPTION
## Summary
- convert database.js to static initialization with createRequire
- expose static `db` object and remove async `createDatabases`
- simplify server setup to import db directly
- drop `injectDB` helpers across app and models
- load default JSON via `require` in curriculum version model

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68881aa190ec832dbd1540ecf1046bb5