### PR TITLE
Fix circular import for Users

### DIFF
--- a/backend/src/features/auth/services/handle-login.js
+++ b/backend/src/features/auth/services/handle-login.js
@@ -1,5 +1,6 @@
 import { UserNotFoundError, PasswordMismatchError, AppError } from "../../../shared/errors/index.js";
 import baseLogger from '../../../../logger/logger.js';
+import Users from '../../users/models/users/users.model.js';
 
 const logger = baseLogger.addSource({
     file: 'auth.service',

--- a/backend/src/features/users/models/users/admin/admins.model.js
+++ b/backend/src/features/users/models/users/admin/admins.model.js
@@ -6,4 +6,6 @@ class Admins extends Users {
     static roleKey = 'admins';
 }
 
+Users.registerRole(Admins.roleKey, Admins);
+
 export default Admins;

--- a/backend/src/features/users/models/users/associate-editor/editors.model.js
+++ b/backend/src/features/users/models/users/associate-editor/editors.model.js
@@ -18,4 +18,6 @@ class AssociateEditors extends Users {
     }
 }
 
+Users.registerRole(AssociateEditors.roleKey, AssociateEditors);
+
 export default AssociateEditors;

--- a/backend/src/features/users/models/users/community-member/members.model.js
+++ b/backend/src/features/users/models/users/community-member/members.model.js
@@ -7,4 +7,6 @@ class CommunityMembers extends Users {
     static roleKey = 'communityMembers';
 }
 
+Users.registerRole(CommunityMembers.roleKey, CommunityMembers);
+
 export default CommunityMembers;

--- a/backend/src/features/users/models/users/editor-in-chief/chiefs.model.js
+++ b/backend/src/features/users/models/users/editor-in-chief/chiefs.model.js
@@ -10,4 +10,6 @@ class EditorsInChief extends Users {
 
 }
 
+Users.registerRole(EditorsInChief.roleKey, EditorsInChief);
+
 export default EditorsInChief;

--- a/backend/src/features/users/models/users/reviewer/reviewers.model.js
+++ b/backend/src/features/users/models/users/reviewer/reviewers.model.js
@@ -19,4 +19,6 @@ class Reviewers extends Users {
 
 }
 
+Users.registerRole(Reviewers.roleKey, Reviewers);
+
 export default Reviewers;

--- a/backend/src/features/users/models/users/users.model.js
+++ b/backend/src/features/users/models/users/users.model.js
@@ -1,13 +1,13 @@
 // models/Users.js
-import CommunityMembers from './community-member/members.model.js';
-import AssociateEditors from './associate-editor/editors.model.js';
-import Reviewers from './reviewer/reviewers.model.js';
-import ChiefEditors from './editor-in-chief/chiefs.model.js';
-import Admins from './admin/admins.model.js';
 import db from '../../../../database/database.js';
 
 export default class Users {
     static dbRef = db.users;
+    static registry = {};
+
+    static registerRole(roleKey, CollectionClass) {
+        this.registry[roleKey] = CollectionClass;
+    }
 
     static getDbRef() {
         const dbRef = this.dbRef[this.roleKey];
@@ -19,14 +19,7 @@ export default class Users {
      * Each entry maps a role key to its plural model class
      */
     static getRegistry() {
-        return {
-            communityMembers: CommunityMembers,
-            associateEditors: AssociateEditors,
-            reviewers: Reviewers,
-            chiefEditors: ChiefEditors,
-            admins: Admins
-            // reviewers: ...
-        };
+        return this.registry;
     }
 
     /**


### PR DESCRIPTION
## Summary
- register role models dynamically to remove circular import
- fix login service missing Users import

## Testing
- `npm run docs` *(fails: jsdoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888221a409c832d9aaf461fce972194